### PR TITLE
Fix #11

### DIFF
--- a/apps/northware-cockpit/package.json
+++ b/apps/northware-cockpit/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo --port 40110",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
northware-cockpit startet bei `next dev`/`pnpm dev`/`turbo dev` jetzt wieder unter `localhost:40110` und mit Turbopack. (`--turbo`)