### PR TITLE
fix(gh-management): dependabot open-pull-request-limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,11 +17,9 @@ updates:
       prefix: "chore(dependabot)"
     labels: 
       - "dependencies"
-    open-pull-requests-limit: 0
     versioning-strategy: increase
 
   - package-ecosystem: github-actions
-    open-pull-requests-limit: 0
     directory: /
     commit-message:
       prefix: 'chore(actions)'


### PR DESCRIPTION
## Beschreibung

The configuration open-pull-requests-limit: 0 disables dependabot version updates. Based on this, the change will hopefully enable dependabot

Comment at dependabot Issue: https://github.com/dependabot/dependabot-core/issues/4993#issuecomment-1326762179 

### Referenzen

Dieser Pull Request löst den Issue #44
