### PR TITLE
fix(github-management): Remove version specification

### DIFF
--- a/.github/workflows/turborepo-ci.yml
+++ b/.github/workflows/turborepo-ci.yml
@@ -27,8 +27,6 @@ jobs:
           fetch-depth: 2
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Beschreibung

Die Definition, welche pnpm Version im Turborepo CI genutzt wird, wird verworfen, damit der Workflow die Version aus der `package.json` nutzt

### Referenzen

Dieser Pull Request löst den Issue #55 
