### PR TITLE
Northware Docs Deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,4 @@
-name: Deploy contributor doc
+name: Deploy docs to GitHub Pages
 
 on:
   push:


### PR DESCRIPTION
## Beschreibung

Der Workflow `deploy-docs.yml` veröffentlicht die Northware Docs automatisch auf dem `gh-pages` branch, womit diese Dokumentation aktuell gehalten wird.

Dieses Feature kam mit mehreren Pull Requests

- #57 
- #58 
- #59 
- #60 

### Referenzen

Dieser Pull Request löst den Issue #46 