### PR TITLE
docs(docs): Documentation of GH Pages deployment

### DIFF
--- a/apps/docs/docs/20-Apps/docs.md
+++ b/apps/docs/docs/20-Apps/docs.md
@@ -1,0 +1,9 @@
+# Northware Docs
+
+## Deployment
+
+Der Workflow "Deploy docs to GitHub Pages" (deploy-docs.yml) deploy die Änderungen im `apps/docs` Ordner (Diese Docusaurus Dokumentation) automatisch auf den Branch `gh-pages`, wenn diese Änderungen auf den `main` Branch gemerget werden.
+
+Das GitHub Repository ist so konfiguriert, dass der Inhalt des Branches `gh-pages` auf der Seite [ncs-northware.github.io/northware/](https://ncs-northware.github.io/northware/) veröffentlicht wird.
+
+Es existiert eine Branch Protection Regel, die verhindert, dass der Branch `gh-pages` automatisch oder manuell gelöscht wird.


### PR DESCRIPTION
## Beschreibung

Es gibt jetzt eine Doku-Seite für die Docs. Dort wird beschrieben, wie die Docs auf GitHub Page veröffentlich werden.

### Referenzen

Dieser Pull Request löst den Issue #62 
