### PR TITLE
Local CI / Rethink Turborepo CI and Test-Tasks

### DIFF
--- a/.github/workflows/turborepo-ci.yml
+++ b/.github/workflows/turborepo-ci.yml
@@ -1,6 +1,6 @@
 name: Turborepo CI
 
-# This Action is building, testing and linting on all changes coming from an PR to test if the code is going to work.
+# This Action is building and linting on all changes coming from an PR to test if the code is going to work.
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test
+    name: Build and Lint
     timeout-minutes: 15
     runs-on: ubuntu-latest
     # To use Remote Caching, uncomment the next lines and follow the steps below.
@@ -42,6 +42,3 @@ jobs:
 
       - name: Lint
         run: pnpm turbo run lint --affected
-
-      - name: Test
-        run: pnpm turbo run test --affected

--- a/apps/docs/docs/40-github-management/workflows.mdx
+++ b/apps/docs/docs/40-github-management/workflows.mdx
@@ -93,7 +93,6 @@ Der Workflow **Turborepo CI** (`.github/workflows/turborepo-ci.yml`) wird immer 
 Der Workflow nutzt den vorliegenden Code und installiert das Projekt in einer Node.js Umgebung mit `pnpm`.
 Mit `pnpm build --affected` werden die von der Änderung betroffenen Code-Teile gebaut. 
 Mit `pnpm lint --affected` werden **Lint-Tests** des betroffenen Codes ausgeführt.
-Schließlich wird der Code noch einmal mit `pnpm test --affected` getestet.
 
 Sollte es während dieses Workflows zu Problemen kommen, wird der Workflow abgebrochen.
 

--- a/apps/docs/docs/40-github-management/workflows.mdx
+++ b/apps/docs/docs/40-github-management/workflows.mdx
@@ -96,6 +96,13 @@ Mit `pnpm lint --affected` werden **Lint-Tests** des betroffenen Codes ausgefüh
 
 Sollte es während dieses Workflows zu Problemen kommen, wird der Workflow abgebrochen.
 
+:::info Local CI
+
+Der Turborepo CI-Workflow durchläuft bei jedem Pull Request und bei jedem Merge die Schritte `pnpm turbo build --affected` und `pnpm turbo run lint --affected`. 
+Damit diese Schritte nicht immer erst gemacht werden, wenn alles fertig ist lässt sich dieser Ablauf mit `pnpm localci` auch lokal abbilden, damit Fehler schon vor dem CI-Durchlauf auffallen.
+
+:::
+
 ### autofix.ci
 
 Der Workflow **autofix.ci** (.github/workflows/autofix.yml) wird immer dann ausgeführt, wenn ein neuer Pull Request hinzugefügt oder geändert wurde.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "lint": "turbo lint",
-    "test": "turbo run test",
-    "localci": "turbo build lint test --affected",
+    "localci": "turbo build lint --affected",
     "format": "prettier --write \"**/*.*\"",
     "commit": "commit"
   },

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "northware",
   "private": true,
   "scripts": {
-    "build": "turbo build",
     "dev": "turbo dev",
+    "build": "turbo build",
     "lint": "turbo lint",
-    "format": "prettier --write \"**/*.*\"",
     "test": "turbo run test",
+    "localci": "turbo build lint test --affected",
+    "format": "prettier --write \"**/*.*\"",
     "commit": "commit"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -15,9 +15,6 @@
     },
     "lint": {
       "dependsOn": ["^lint"]
-    },
-    "test": {
-      "dependsOn": ["^build"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", "build/**"]
     },
     "dev": {
       "inputs": ["$TURBO_DEFAULT$", ".env*"],


### PR DESCRIPTION
## Beschreibung

- Es gibt jetzt keine Testing-Commands mehr #65 (WONTFIX)
- Die Schritte des Turborepo CI sind mit `pnpm localci` lokal nachgebaut. #43 