### PR TITLE
chore(gh-management): Permissions for Auto Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   pull-requests: write
+  contents: write
 
 jobs:
   release:


### PR DESCRIPTION
## Beschreibung

Write Permissions für Pull-Requests scheinen nicht auszureichen. Ich gebe dem Worflow auch Write-Permissions für contents und hoffe, dass das ausreicht.
