### PR TITLE
Invalid workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
     reviewers:
       - "onissen"
     commit-message: 
-      prefix: "chore(dependabot)"
+      prefix: "chore(update-pnpm)"
     labels: 
       - "dependencies"
     versioning-strategy: increase
@@ -22,10 +22,12 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     commit-message:
-      prefix: 'chore(actions)'
+      prefix: 'chore(update-actions)'
     schedule:
       interval: weekly
       day: friday
       time: '14:00'
     labels:
       - 'github-actions'
+    reviewers:
+      - "onissen"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,6 +8,7 @@ turborepo:
       - all-globs-to-all-files: "!.github/**"
       - all-globs-to-all-files: "!apps/**"
       - all-globs-to-all-files: "!packages/**"
+      - all-globs-to-all-files: "!pnpm-lock.yaml"
 
 # Labels for Github Health Files
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,7 +4,10 @@
 turborepo:
   - changed-files:
       - any-glob-to-any-file: "*"
-      - all-globs-to-all-files: "!.changeset/*"
+      - all-globs-to-all-files: "!.changeset/**"
+      - all-globs-to-all-files: "!.github/**"
+      - all-globs-to-all-files: "!apps/**"
+      - all-globs-to-all-files: "!packages/**"
 
 # Labels for Github Health Files
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+# concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Beschreibung

Es wurden einige Verbesserungen der Workflows vorgenommen.

### dependabot.yml

- Der Prefix macht deutlich, dass es hier um das Package Ökosystem (PNPM oder GH Actions) und nicht um den Bot geht
- Auch bei Updates der Github Actions wird ein Review angefordert.

### labeler.yml
Das Label `turborepo` soll nur an Pull Requests vergeben werden, die die Root-Dateien (ausgenommen pnpm-lock.yaml) ändern

### release.yml
Versuch: Auch auf dem Release PR sollen die CI Tests durchlaufen

