### PR TITLE
Invalid workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@
 
 turborepo:
   - changed-files:
-      - any-glob-to-any-file: "*"
+      - all-globs-to-all-files: "*"
       - all-globs-to-all-files: "!.changeset/**"
       - all-globs-to-all-files: "!.github/**"
       - all-globs-to-all-files: "!apps/**"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 
-# concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Beschreibung

- Die Konfiguration von Labeler in Hinsicht auf das `turborepo` Label wurde nochmal geändert in der Hoffnung, dass das Label jetzt nur dann genutzt wird, wenn es tatsächlich genutzt werden soll
- Reenable `concurrency` in `release.yml` to let it work propperly
