### PR TITLE
Labler Exeption turborepo

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,14 +1,4 @@
 # This file serves as configuration file for the labeler Workflow (.github/workflows/pr_labeler.yml)
-# Labels for Repo-Root (Turborepo Administration)
-
-turborepo:
-  - changed-files:
-      - all-globs-to-all-files: "*"
-      - all-globs-to-all-files: "!.changeset/**"
-      - all-globs-to-all-files: "!.github/**"
-      - all-globs-to-all-files: "!apps/**"
-      - all-globs-to-all-files: "!packages/**"
-      - all-globs-to-all-files: "!pnpm-lock.yaml"
 
 # Labels for Github Health Files
 

--- a/apps/docs/docs/40-github-management/projectmanagement.mdx
+++ b/apps/docs/docs/40-github-management/projectmanagement.mdx
@@ -102,7 +102,7 @@ der Hintergrundfarbe <span style={{color: 'black', background: '#F0B9F8'}}>#F0B9
 
 | Label                                                                                | Beschreibung                                                                  |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| <GithubBadge background="#765EB0" color="white">turborepo</GithubBadge> | Dieser Issue/PR ändert etwas der Turborepo-Konfiguration bzw. an den Dateien im Root-Verzeichnis |
+| <GithubBadge background="#765EB0" color="white">turborepo</GithubBadge> | Dieser Issue/PR ändert etwas der Turborepo-Konfiguration bzw. an den Dateien im Root-Verzeichnis. **Dieses Label wird nicht automatisch an Pulll Requests vergeben.** Da es hier zu Komplikationen bei Änderungen der anderen Codeteile kommt. |
 | <GithubBadge background="black" color="white">github-management</GithubBadge> | Dieser Issue/PR ändert etwas an der Konfiguration für GitHub. Das kann Dateien im `.github/` Ordner, das Northware New Projekt und Einstellungen des Repositories betreffen.  |
 
 ### Labels für Bots und Workflows


### PR DESCRIPTION
## Beschreibung

Das Label turborepo ist nur für Root-Änderungen und die Turborepo Administration gedacht. Da aber alle Dateien im Root liegen, vergibt Labeler bei jedem PR dieses Label. Zukänftig wird Labeler dieses Label nicht vergeben. Wenn gewünscht muss es manuell vergeben werden.