### PR TITLE
fix(cockpit): Silence Sass Deprecation Notice Legacy JS API

### DIFF
--- a/apps/northware-cockpit/next.config.mjs
+++ b/apps/northware-cockpit/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  sassOptions: {
+    silenceDeprecations: ["legacy-js-api"],
+  },
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Beschreibung

Da Next.js aktuell noch die Sass Legacy JS API nutzt und das erst mit einem Update von Next.js behoben werden kann, wird dieses Warning vorrübergehend ignoriert.

### Referenzen

Dieser Pull Request hat mit dem Issue #123 zu tun. Es ist aber nur ein vorrübergehendes Handling und kein fix des Issues.
