### PR TITLE
chore(gh-management): Update @docusaurus/* dependencies as a group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       interval: "weekly"
       day: "friday"
       time: "14:00"
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
     reviewers:
       - "onissen"
     commit-message: 
@@ -20,7 +24,7 @@ updates:
     versioning-strategy: increase
 
   - package-ecosystem: github-actions
-    directory: /
+    directory: "/"
     commit-message:
       prefix: 'chore(update-actions)'
     schedule:


### PR DESCRIPTION
Um Kompatibilitätsprobleme zwischen verschiedenen Versionen der Docusaurus Dependencies möglichst zu vermeiden, soll dependabot diese Dependencies künftig als Gruppe updaten.

