### PR TITLE
fix(root): Prettier-Anpassungen

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,9 @@ pnpm-lock.yaml
 # Generated files
 .nojekyll
 
+# TypeScript generated
+tsconfig.tsbuildinfo
+
 # Please ignore ingnore files lol
 .gitignore
 .prettierignore
@@ -26,7 +29,6 @@ pnpm-lock.yaml
 *.svg
 *.mdx
 *.sass
-tsconfig.json
 
 # The autofix.ci workflow has no permission to change files in .guthub
 **/.github/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
   "plugins": ["prettier-plugin-tailwindcss"],
-  "tailwindConfig": "packages/tailwind-config/tailwind.config.js"
+  "tailwindConfig": "packages/tailwind-config/tailwind.config.ts"
 }


### PR DESCRIPTION
- Prettier muss jetzt auf die `tailwind.config.ts` und nicht auf `tailwind.config.js` zugreifen, da die Datei migriert wurde. 
- Die von TypeScript generierte `tsconfig.tsbuildinfo` soll von Prettier nicht beachtet werden

### Referenzen

Dieser Pull Request löst den Issue #
