### PR TITLE
fix(cockpit): Uninstall Sass

### DIFF
--- a/apps/northware-cockpit/package.json
+++ b/apps/northware-cockpit/package.json
@@ -17,13 +17,12 @@
     "next": "15.0.3",
     "next-auth": "5.0.0-beta.25",
     "react": "^18",
-    "react-dom": "^18",
-    "sass": "^1.80.6"
+    "react-dom": "^18"
   },
   "devDependencies": {
-    "@northware/tsconfig": "workspace:*",
     "@northware/eslint-config": "workspace:*",
     "@northware/tailwind-config": "workspace:*",
+    "@northware/tsconfig": "workspace:*",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.14.0",
     "eslint-config-next": "^15.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,9 +96,6 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
-      sass:
-        specifier: ^1.80.6
-        version: 1.80.6
     devDependencies:
       '@northware/eslint-config':
         specifier: workspace:*
@@ -12266,6 +12263,7 @@ snapshots:
   chokidar@4.0.1:
     dependencies:
       readdirp: 4.0.2
+    optional: true
 
   chrome-trace-event@1.0.4: {}
 
@@ -14182,7 +14180,8 @@ snapshots:
 
   immer@9.0.21: {}
 
-  immutable@4.3.7: {}
+  immutable@4.3.7:
+    optional: true
 
   import-fresh@3.3.0:
     dependencies:
@@ -16129,7 +16128,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  readdirp@4.0.2: {}
+  readdirp@4.0.2:
+    optional: true
 
   reading-time@1.5.0: {}
 
@@ -16394,6 +16394,7 @@ snapshots:
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.4.1
+    optional: true
 
   sax@1.4.1: {}
 


### PR DESCRIPTION
Since the Projekt is using Plain CSS with Plain Tailwind now, the sass dependency is unused and not needed.

This is reated to #141 but not the point of this isssue.