### PR TITLE
Config-File Migrations

### DIFF
--- a/apps/northware-cockpit/next.config.mjs
+++ b/apps/northware-cockpit/next.config.mjs
@@ -1,8 +1,0 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  sassOptions: {
-    silenceDeprecations: ["legacy-js-api"],
-  },
-};
-
-export default nextConfig;

--- a/apps/northware-cockpit/next.config.ts
+++ b/apps/northware-cockpit/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // Configuration Options here
+};
+
+export default nextConfig;

--- a/apps/northware-cockpit/postcss.config.js
+++ b/apps/northware-cockpit/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/northware-cockpit/postcss.config.mjs
+++ b/apps/northware-cockpit/postcss.config.mjs
@@ -1,9 +1,0 @@
-/** @type {import('postcss-load-config').Config} */
-const config = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};
-
-export default config;

--- a/packages/ui/postcss.config.js
+++ b/packages/ui/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/packages/ui/postcss.config.mjs
+++ b/packages/ui/postcss.config.mjs
@@ -1,9 +1,0 @@
-/** @type {import('postcss-load-config').Config} */
-const config = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};
-
-export default config;


### PR DESCRIPTION
## Beschreibung

- Die `postcss.config.js` in `northware-cockpit` und `@northware/ui` bleibt eine JavaScript Datei. Durch Vereinfachungen des Codes ist die Verwendung von `.mjs` nicht nötig.
- cockpit: Die `next.config.ts` verwendet jetzt TypeScript. Da im Northware Projekt kein Sass mehr verwendet wird, sind aktuell keine Konfigurationen für Next.js nötig.

### Referenzen

Dieser Pull Request ist Teil des TypeScript Migration Milestones #142 
