### PR TITLE
Aliase für absolute Paths in @northware/ui und northware-cockpit

### DIFF
--- a/apps/northware-cockpit/tsconfig.json
+++ b/apps/northware-cockpit/tsconfig.json
@@ -4,6 +4,7 @@
     "plugins": [{ "name": "next" }],
     "baseUrl": ".",
     "paths": {
+      "@/*": ["./src/*"],
       "@northware/ui/*": ["../../packages/ui/src/*"]
     }
   },

--- a/apps/northware-cockpit/tsconfig.json
+++ b/apps/northware-cockpit/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "extends": "@northware/tsconfig/nextjs.json",
   "compilerOptions": {
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "baseUrl": ".",
+    "paths": {
+      "@northware/ui/*": ["../../packages/ui/src/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,7 +10,8 @@
   "exports": {
     "./components": "./src/components/index.ts",
     "./css": "./src/css/output.css",
-    "./fonts": "./src/fonts.ts"
+    "./fonts": "./src/fonts.ts",
+    "./utils": "./src/utils.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/packages/ui/src/components/base/Button.tsx
+++ b/packages/ui/src/components/base/Button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
-import { cn } from "../../utils";
+import { cn } from "@northware/ui/utils";
 
 const buttonVariants = cva(
   "flex items-center justify-center gap-2 rounded-md text-center font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-opacity-50 border-2 border-transparent shadow-md",

--- a/packages/ui/src/components/base/Headline.tsx
+++ b/packages/ui/src/components/base/Headline.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, HTMLAttributes } from "react";
-import { cn } from "../../utils";
+import { cn } from "@northware/ui/utils";
 
 interface HeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
   children: ReactNode;

--- a/packages/ui/src/components/form-parts/Form.tsx
+++ b/packages/ui/src/components/form-parts/Form.tsx
@@ -11,9 +11,8 @@ import {
   FormProvider,
   useFormContext,
 } from "react-hook-form";
-
-import { cn } from "../../utils";
-import { Label } from "./Label";
+import { cn } from "@northware/ui/utils";
+import { Label } from "@northware/ui/components/form-parts/Label";
 
 const Form = FormProvider;
 

--- a/packages/ui/src/components/form-parts/Input.tsx
+++ b/packages/ui/src/components/form-parts/Input.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
-
-import { cn } from "../../utils";
 import { cva, VariantProps } from "class-variance-authority";
+import { cn } from "@northware/ui/utils";
 
 const inputVariants = cva(
   "flex h-10 w-full rounded-md border border-input bg-background text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",

--- a/packages/ui/src/components/form-parts/Label.tsx
+++ b/packages/ui/src/components/form-parts/Label.tsx
@@ -3,8 +3,7 @@
 import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva, type VariantProps } from "class-variance-authority";
-
-import { cn } from "../../utils";
+import { cn } from "@northware/ui/utils";
 
 const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",

--- a/packages/ui/src/components/form-parts/Select.tsx
+++ b/packages/ui/src/components/form-parts/Select.tsx
@@ -3,8 +3,7 @@
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
-
-import { cn } from "../../utils";
+import { cn } from "@northware/ui/utils";
 
 const Select = SelectPrimitive.Root;
 

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -12,7 +12,7 @@ export * from "@northware/ui/components/form-parts/Select";
 export * from "@northware/ui/components/layouts/Container";
 
 // Menu (Components that define Menus or Parts of it or Components that are used for Navigation)
-export * from "./menu/DropdownMenu";
+export * from "@northware/ui/components/menu/DropdownMenu";
 
 // NextThemes (Components that are used to perform the NextThemes integration)
 export * from "./next-themes/DarkModeToggle";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,6 +1,6 @@
 // Base Components (Basics to use instead of HTML Elements or Components that are used often)
-export * from "./base/Button";
-export * from "./base/Headline";
+export * from "@northware/ui/components/base/Button";
+export * from "@northware/ui/components/base/Headline";
 
 // Form Parts (Components that are typically part of a Form)
 export * from "./form-parts/Form";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -9,7 +9,7 @@ export * from "@northware/ui/components/form-parts/Label";
 export * from "@northware/ui/components/form-parts/Select";
 
 // Layouts (Components to define Page Layouts)
-export * from "./layouts/Container";
+export * from "@northware/ui/components/layouts/Container";
 
 // Menu (Components that define Menus or Parts of it or Components that are used for Navigation)
 export * from "./menu/DropdownMenu";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -3,10 +3,10 @@ export * from "@northware/ui/components/base/Button";
 export * from "@northware/ui/components/base/Headline";
 
 // Form Parts (Components that are typically part of a Form)
-export * from "./form-parts/Form";
-export * from "./form-parts/Input";
-export * from "./form-parts/Label";
-export * from "./form-parts/Select";
+export * from "@northware/ui/components/form-parts/Form";
+export * from "@northware/ui/components/form-parts/Input";
+export * from "@northware/ui/components/form-parts/Label";
+export * from "@northware/ui/components/form-parts/Select";
 
 // Layouts (Components to define Page Layouts)
 export * from "./layouts/Container";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -22,4 +22,4 @@ export * from "@northware/ui/components/next-themes/ThemeProvider";
 export * from "@northware/ui/components/panels/Card";
 
 // Specific (Components that are used for a specific feature)
-export * from "./specific/Login";
+export * from "@northware/ui/components/specific/Login";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -15,8 +15,8 @@ export * from "@northware/ui/components/layouts/Container";
 export * from "@northware/ui/components/menu/DropdownMenu";
 
 // NextThemes (Components that are used to perform the NextThemes integration)
-export * from "./next-themes/DarkModeToggle";
-export * from "./next-themes/ThemeProvider";
+export * from "@northware/ui/components/next-themes/DarkModeToggle";
+export * from "@northware/ui/components/next-themes/ThemeProvider";
 
 // Panels (Components to Display Content in a special way)
 export * from "./panels/Card";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -19,7 +19,7 @@ export * from "@northware/ui/components/next-themes/DarkModeToggle";
 export * from "@northware/ui/components/next-themes/ThemeProvider";
 
 // Panels (Components to Display Content in a special way)
-export * from "./panels/Card";
+export * from "@northware/ui/components/panels/Card";
 
 // Specific (Components that are used for a specific feature)
 export * from "./specific/Login";

--- a/packages/ui/src/components/layouts/Container.tsx
+++ b/packages/ui/src/components/layouts/Container.tsx
@@ -1,5 +1,5 @@
+import { cn } from "@northware/ui/utils";
 import { ReactNode } from "react";
-import { cn } from "../../utils";
 
 export function Container({
   children,

--- a/packages/ui/src/components/menu/DropdownMenu.tsx
+++ b/packages/ui/src/components/menu/DropdownMenu.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { Check, ChevronRight, Circle } from "lucide-react";
 
-import { cn } from "../../utils";
+import { cn } from "@northware/ui/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 

--- a/packages/ui/src/components/next-themes/DarkModeToggle.tsx
+++ b/packages/ui/src/components/next-themes/DarkModeToggle.tsx
@@ -1,15 +1,13 @@
 "use client";
-
-import { Button } from "../base/Button";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
-
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from "../menu/DropdownMenu";
+} from "@northware/ui/components/menu/DropdownMenu";
+import { Button } from "@northware/ui/components/base/Button";
 
 export function DarkModeToggle() {
   const { setTheme } = useTheme();

--- a/packages/ui/src/components/panels/Card.tsx
+++ b/packages/ui/src/components/panels/Card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { cn } from "../../utils";
+import { cn } from "@northware/ui/utils";
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/packages/ui/src/components/specific/Login.tsx
+++ b/packages/ui/src/components/specific/Login.tsx
@@ -8,14 +8,19 @@ import {
   FormLabel,
   FormControl,
   FormMessage,
-} from "../form-parts/Form";
-import { Input } from "../form-parts/Input";
+} from "@northware/ui/components/form-parts/Form";
+import { Input } from "@northware/ui/components/form-parts/Input";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Image from "next/image";
-import { Card, CardContent, CardHeader, CardTitle } from "../panels/Card";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@northware/ui/components/panels/Card";
 import { useTheme } from "next-themes";
-import { Button } from "../base/Button";
+import { Button } from "@northware/ui/components/base/Button";
 
 const formSchema = z.object({
   email: z.string(),

--- a/packages/ui/src/components/specific/Login.tsx
+++ b/packages/ui/src/components/specific/Login.tsx
@@ -32,10 +32,11 @@ export function LoginForm({ onSubmit }: { onSubmit: (values: any) => void }) {
   return (
     <>
       <Image
+        suppressHydrationWarning
         src={
           theme.resolvedTheme === "dark"
-            ? "/img/logo-dark.svg"
-            : "/img/logo-light.svg"
+            ? "/img/logo-light.svg"
+            : "/img/logo-dark.svg"
         }
         height={150}
         width={380}

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "@northware/tsconfig/react-library.json",
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@northware/ui/*": ["src/*"]
+    }
+  }
 }


### PR DESCRIPTION
## Beschreibung

- Innerhalb von `@northware/ui` ist jetzt der Alias `@northare/ui` für absolute Importe innerhalb des Packages konfiguriert.

**Vorher**
```tsx
import { Label } from "./Label";
```

**Nachher**
```tsx
import { Label } from "@northware/ui/components/form-parts/Label";
```

- Die gleiche Konfiguration ist auch in `northware-cockpit` definiert, damit die imports aus dem Package funktionieren.

- Im `northware-cockpit` ist außerdem der Alias `@/*` für absolute Imports innerhalb der App zu ermöglichen

- Die Utility-Funktionen aus `utils.ts` werden jetzt unter `@northware/ui/utils` exportiert.