### PR TITLE
fix(cockpit): JSX.Element leads to TypeScript Errors with @types/react@19.0.2

### DIFF
--- a/apps/northware-cockpit/src/app/layout.tsx
+++ b/apps/northware-cockpit/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
-}): JSX.Element {
+}) {
   return (
     <html className="theme-cockpit" lang="de" suppressHydrationWarning>
       <body className={`${source_sans.variable} font-sans`}>


### PR DESCRIPTION
## Beschreibung

Die Typdefinition `JSX.Element` als Type von `RootLayout` führte mit `@types/ract@19.0.2` und `react@19.0.0` zu einem TypeScript Validierungsfehler.

Diese Typdefinition ist wohl nicht mehr nötig. Auch in der [Dokumentation von Next.js](https://nextjs.org/docs/app/getting-started/layouts-and-pages#creating-a-layout) ist sie nicht zu sehen.