### PR TITLE
Config Labeler to use packages/database and api Label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,7 +22,7 @@ packages/auth:
   - changed-files:
       - any-glob-to-any-file: packages/auth/**
 
-packages/database:
+packages/database and api:
   - changed-files:
       - any-glob-to-any-file: packages/database/**
 


### PR DESCRIPTION
## Beschreibung

In der Konfiguration von Labeler war definiert, dass für Änderungen an Dateien in`packages/database` das gleichnamige Label verwendet werden soll.

Seitdem dieses Label in `packages/database and api` umbenannt wurde, legte Labeler für Änderungen an diesen Dateien selbstständig das Label `packages/database` an. Mit der Änderung der Konfiguration sollte dieses jetzt behoben sein.

### Referenzen

Dieser Pull Request löst den Issue #206 
