### PR TITLE
chore(root): Prettier Config: Ignore .gitkeep files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,7 +3,6 @@ pnpm-lock.yaml
 
 # Generated Codes on root
 **/.git/
-**/.gitkeep/
 **/.turbo/
 **/.vscode/
 **/node_modules

--- a/.prettierignore
+++ b/.prettierignore
@@ -21,6 +21,7 @@ pnpm-lock.yaml
 # Please ignore ingnore files lol
 .gitignore
 .prettierignore
+.gitkeep
 
 # Different File Types
 *.png

--- a/empty.md
+++ b/empty.md
@@ -1,1 +1,0 @@
-Dies ist eine leere Datei


### PR DESCRIPTION
## Beschreibung

Die .gitkeep Dateien sollen von Prettier nicht beobachtet werden. So funktioniert auch autofix.ci wieder.
