### PR TITLE
fix(renovate): Ignore package managers and engines

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,5 +12,6 @@
     "reviewers": ["onissen"]
   },
   "dependencyDashboardLabels": ["dependencies", "github-management"],
-  "dependencyDashboardTitle": "[Renovate]: Dependency Dashboard"
+  "dependencyDashboardTitle": "[Renovate]: Dependency Dashboard",
+  "ignoreDeps": ["pnpm"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,5 +13,5 @@
   },
   "dependencyDashboardLabels": ["dependencies", "github-management"],
   "dependencyDashboardTitle": "[Renovate]: Dependency Dashboard",
-  "ignoreDeps": ["pnpm"]
+  "ignoreDeps": ["node", "npm", "pnpm", "yarn"]
 }


### PR DESCRIPTION
## Beschreibung

Die Einträge der benötigten Versionen von `node`, `npm`, `pnpm` und `yarn` sollen von renovate nicht geändert werden, da viele Dependencies nicht schnell mit neuen Versionen kompatibel werden.

### Referenzen

- close #237 
- close #261 
- close #257 