### PR TITLE
fix(cockpit): Remove JSX.Element Type Declaration

### DIFF
--- a/apps/northware-cockpit/src/app/layout.tsx
+++ b/apps/northware-cockpit/src/app/layout.tsx
@@ -14,7 +14,7 @@ export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
-}): JSX.Element {
+}) {
   return (
     <html className="theme-cockpit" lang="de" suppressHydrationWarning>
       <body className={`${source_sans.variable} font-sans`}>


### PR DESCRIPTION
# Beschreibung

In React 19 ist die Typdeklaration `JSX.Element` als Typ für das Layout deprecated und außerdem wird sie von Next.js nicht mehr verwendet. Es ist keine Typdeklaration an dieser Stelle mehr notwendig.
