### PR TITLE
fix(biome): Ignore build-folders in .foldername Folders, use biomeVersions config in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "customManagers:biomeVersions"],
   "semanticCommits": "enabled",
   "labels": ["dependencies"],
   "reviewers": ["onissen"],

--- a/biome.json
+++ b/biome.json
@@ -7,6 +7,10 @@
   "files": {
     "ignore": [
       "**/node_modules/**",
+      "**/.turbo",
+      "**/.docusaurus",
+      "**/.next",
+      "tsconfig.tsbuildinfo",
       "**/dist/**",
       "**/css/output.css",
       "apps/docs/src/theme/**"


### PR DESCRIPTION
## Beschreibung

Biome ignoriert jetzt die automatisch generierten Build-Ordner .turbo, .next, .docusaurus und die tsconfig.tsbuildinfo. Renovate nutzt jetzt das Config-Preset customManagers:biomeVersions