### PR TITLE
Docs about Biome and Ultracite / Biome Improovements

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm install
 
       - name: Code formatting with Biome and Ultracite
-        run: pnpm turbo run format:root --affected
+        run: pnpm turbo run format:root
 
       - name: Apply fixes
         uses: autofix-ci/action@ff86a557419858bb967097bfc916833f5647fa8c

--- a/.github/workflows/turborepo-ci.yml
+++ b/.github/workflows/turborepo-ci.yml
@@ -41,7 +41,4 @@ jobs:
         run: pnpm turbo run build --affected
 
       - name: Lint on Root with Biome and Ultracite
-        run: pnpm turbo run lint:root --affected
-
-      # - name: Lint Packages and Apps
-      #   run: pnpm turbo run lint --affected
+        run: pnpm turbo run lint:ci

--- a/apps/docs/docs/10-General/formatting.md
+++ b/apps/docs/docs/10-General/formatting.md
@@ -1,0 +1,72 @@
+# Code Formatierung und Linting
+
+[Biome](https://biomejs.dev/) übernimmt das Code Formatting und Linting in diesem Projekt.
+
+Biome ist in das Root-Package des Projektes integriert und wird in der `biome.json` konfiguriert. Als Startpunkt nutzt Biome das Pre-Config Package [Ultracite](https://www.ultracite.dev/). In der `biome.json` sind ebenfalls einige Ordner und Dateien definiert, die von Biome ignoriert werden. Insbesondere sind dies automatisch und ebenfalls von Git ignorierte automatisch generierte Ordner und Dateien und Ordner, die beim Build-Prozess automatisch erstellt werden.
+
+## CLI Commands
+
+### Ultracite CLI
+
+- **`pnpm ultracite lint`** führt den Biome Linter aus, ohne das Formatierungen angewendet werden. Stattdessen wird gewarnt, dass Formatierungen falsch sind. Hinter diesem Command steckt die Anweisung `npx biome check ./`.
+- **`pnpm ultracite format`** führt den Biome Linter aus und wendet empfohlene Formatierungen auf die Dateien an. Hinter diesem Command steckt die Anweisung `npx biome check --write ./`.
+
+### Biome CLI
+
+Die [Biome CLI](https://biomejs.dev/reference/cli/) bietet viele weitere Möglichkeiten Code zu testen und zu berichtigen.
+
+- [**`biome rage`**](https://biomejs.dev/reference/cli/#biome-rage) zeigt Informationen zum Debugging. `biome rage --formatter` zeigt die angewendeten Formatter Optionen, `biome rage --linter` zeigt die angewendeten Linter-Optionen.
+- [**`biome check`**](https://biomejs.dev/reference/cli/#biome-check) führt den Biome Formatter und Linter aus und prüft die Import-Sortierung. Es werden keine Änderungen an den Dateien vorgenommen.
+  - `--write` ändert die Dateien so, dass sichere Fixes, vorgeschlages Formatting und Import-Sortierungen angewendet werden. `--fix` ist ein Alias für `--write`
+  - `--unsafe` wendet in Kombination mit `--write` oder `--fix` auch unsichere Fixes an. Diese könnten dazu führen, dass der Code nicht mehr funktioniert.
+  - `--formatter-enabled=<true|false>` kontrolliert, ob der Formatter Check ausgeführt wird oder nicht.
+  - `--linter-enabled=<true|false>` kontrolliert, ob der Lint Check ausgeführt wird oder nicht.
+  - `--organize-imports-enabled=<true|false>` kontrolliert, ob Imports sortiert werden sollen, oder nicht.
+  - `--assists-enabled=<true|false>` aktiviert oder deaktiviert die Assists.
+  - `--changed` lintet nur die Dateien, die im Vergleich zum `defaultBranch` verändert wurden.
+- [**`biome ci`**](https://biomejs.dev/reference/cli/#biome-ci) führt Formatter Linter und Import-Sortierung aus. Dieser Command funktioniert wie der Command `biome check` ist aber speziell für die Verwendung im CI-Umfeld optimiert.
+  - `--formatter-enabled=<true|false>` kontrolliert, ob der Formatter Check ausgeführt wird oder nicht.
+  - `--linter-enabled=<true|false>` kontrolliert, ob der Lint Check ausgeführt wird oder nicht.
+  - `--organize-imports-enabled=<true|false>` kontrolliert, ob Imports sortiert werden sollen, oder nicht.
+  - `--assists-enabled=<true|false>` aktiviert oder deaktiviert die Assists.
+  - `--changed` lintet nur die Dateien, die im Vergleich zum `defaultBranch` verändert wurden.
+
+### Anwendung in diesem Projekt
+
+Im Root-Package des Projektes sind mehrere Commands definiert, um die Biome CLI.
+
+- **`pnpm lint:root`** führt den Command `ultracite lint` in allen Teilen des Projektes aus. Es werden das Root-Verzeichnis sowie alle Unterordner incl. `apps/` und `packages/` geprüft. Eine Formatierung wird nicht vorgenommen. Da dieser Command auch als Turbo Task definiert ist, ist `pnpm turbo lint:root` gleichbedeutend.
+- **`pnpm lint`** führt den Command `turbo lint` aus. Dieser Command stößt den Tubo-Task `lint` an. `pnpm turbo lint` ist gleichbedeutend.
+- **`pnpm format:root`** führt den Command `ultracite format` in allen Teilen des Projektes aus. Es werden das Root-Verzeichnis sowie alle Unterordner incl. `apps/` und `packages/` geprüft. Formatierungen werden ggf. angepasst. Da dieser Command auch als Turbo Task definiert ist, ist `pnpm turbo format:root` gleichbedeutend.
+- **`pnpm format`** führt den Command `turbo format` aus. Dieser Command stößt den Tubo-Task `format` an. `pnpm turbo format` ist gleichbedeutend.
+- **`pnpm lint:ci`** ist ein Command speziell für den Turborepo CI Workflow und `pnpm localci`. Hier wird `biome ci ./` ausgeführt, was gleichbedeutend mit `pnpm lint` aber für den Einsatz in CI-Workflows optimiert ist.
+
+#### Turbo Tasks
+
+- **`pnpm turbo lint`** führt das Script `lint` in allen Apps und Packages aus, in denen ein solches Script definiert ist. In allen `package.json` sollte daher ein Script definiert sein, dass hinter dem Script `lint` den Command `ultracite lint` ausführt.
+- **`pnpm turbo format`** führt das Script `format` in allen Apps und Packages aus, in denen ein solches Script definiert ist. In allen `package.json` sollte daher ein Script definiert sein, dass hinter dem Script `format` den Command `ultracite format` ausführt.
+
+```json title="package.json"
+
+{
+    "name":"@northware/ui",
+    ...
+    "scripts": {
+        ...
+        "lint": "ultracite lint",
+        "format": "ultracite format"
+        ...
+    },
+}
+
+```
+
+:::warning[Warum `pnpm lint` und `pnpm format` nicht ohne `--filter` genutzt werden sollten]
+
+Die Commands `pnpm lint:root` und `pnpm format:root` wenden den Biome Linter und Formatter auf alle Dateien des Packages an. `pnpm lint` und `pnpm format` greifen auf die selbe Config-Datei zu und führen den selben Command in den Apps und Packages des Projektes aus.
+
+`pnpm lint` und `pnpm format` sind dafür gedacht, die Ausführung des Biome Linters und Formatters mit dem `--filter` Flag nur auf einzelne Apps und Packages anzuwenden. Sollen alle Teile des Projektes geprüft werden, sollten `pnpm lint:root` oder `pnpm format:root` ausgeführt werden.
+
+Keinesfalls sollten `pnpm format` und `pnpm format:root` sowie `pnpm lint` und `pnpm lint:root` kombiniert werden, da dann beide Commands die selbe Arbeit erledigen.
+
+:::

--- a/apps/docs/docs/40-github-management/projectmanagement.mdx
+++ b/apps/docs/docs/40-github-management/projectmanagement.mdx
@@ -97,7 +97,6 @@ der Hintergrundfarbe <span style={{color: 'black', background: '#F0B9F8'}}>#F0B9
 | <GithubBadge background="#F0B9F8" color="black">packages/database</GithubBadge> | Dieser Issue/PR ändert etwas an dem `@northware/database` Package |
 | <GithubBadge background="#F0B9F8" color="black">packages/tsconfig</GithubBadge> | Dieser Issue/PR ändert etwas an dem `@northware/tsconfig` Package |
 | <GithubBadge background="#F0B9F8" color="black">packages/tailwind-config</GithubBadge> | Dieser Issue/PR ändert etwas an dem `@northware/tailwind-config` Package |
-| <GithubBadge background="#F0B9F8" color="black">packages/eslint-config</GithubBadge> | Dieser Issue/PR ändert etwas an dem `@northware/eslint-config` Package |
 
 ### Labels für andere Dateipfade
 

--- a/apps/docs/docs/40-github-management/projectmanagement.mdx
+++ b/apps/docs/docs/40-github-management/projectmanagement.mdx
@@ -38,7 +38,7 @@ Wenn Issues nur wegen der Referenzierung oder automatisch verlinkt werden, obwoh
 
 :::
 
-Der Wokflow [Labeler](./workflows#labeler) labeled den Pull Request basierend auf den geänderten Dateien mit den richtigen <GithubBadge borderColor="black">apps/</GithubBadge> oder <GithubBadge background="#F0B9F8" color="black">packages/</GithubBadge> Labels.
+Der Wokflow [Labeler](./workflows#labeler) labeled den Pull Request basierend auf den geänderten Dateien mit den richtigen <GithubBadge borderColor="black" color="black" background="white">apps/</GithubBadge> oder <GithubBadge background="#F0B9F8" color="black">packages/</GithubBadge> Labels.
 
 Jeder Pull Request wird automatisch dem Projekt **Northware New** mit dem Status <GithubBadge statusTheme="blue">Triage</GithubBadge> hinzugefügt und muss vom Nutzer ggf. angepasst werden. Pull Requests an denen noch gearbeitet wird sollen den Status <GithubBadge statusTheme="yellow">In Progress</GithubBadge> erhalten. Wenn die Änderungen des PR noch auf ein Review warten, erhalten sie den Status <GithubBadge statusTheme="pink">For Review</GithubBadge>. Wenn der PR gemerged wurde, wird er automatisch dem Status <GithubBadge statusTheme="purple">Done</GithubBadge> zugeordnet.
 
@@ -48,7 +48,7 @@ Mit Labels lassen sich Issues und Pull Requests kategorisieren. Labels sind bei 
 denn auf Basis dieser Kennzeichnungen werden teilweise Workflows abgearbeitet und Filter gesetzt.
 
 Es gibt bei der Entwicklung von Northware Labels, die den Typ eines Issues oder Pull Requests kennzeichnen (z.B. <GithubBadge background="#A2EEEF" color="black">enhancement</GithubBadge>),
-Labels die betroffene Codeteile (<GithubBadge borderColor="black" color="black">apps/</GithubBadge> und <GithubBadge background="#F0B9F8" color="black">packages/</GithubBadge> Labels) und
+Labels die betroffene Codeteile (<GithubBadge borderColor="black" color="black" background="white">apps/</GithubBadge> und <GithubBadge background="#F0B9F8" color="black">packages/</GithubBadge> Labels) und
 Labels die von Bots und Workflows verwendet werden (z.B. <GithubBadge background="#0366D6" color="white">dependencies</GithubBadge> und <GithubBadge background="black" color="white">github-actions</GithubBadge>).
 
 ### Type Labels
@@ -147,7 +147,7 @@ Diese Ansich ebthält alle Einträge, die das Northware New Projekt enthält
 
 #### Apps
 
-In dieser Ansicht werden alle Einträge angezeigt, die ein <GithubBadge color="black" borderColor="black">apps/</GithubBadge> Label haben und daher eine Änderung einer oder mehrerer Apps bewirken.
+In dieser Ansicht werden alle Einträge angezeigt, die ein <GithubBadge color="black" borderColor="black" background="white">apps/</GithubBadge> Label haben und daher eine Änderung einer oder mehrerer Apps bewirken.
 
 #### Packages
 

--- a/apps/docs/docs/40-github-management/projectmanagement.mdx
+++ b/apps/docs/docs/40-github-management/projectmanagement.mdx
@@ -10,7 +10,7 @@ Im Northware Repository gibt es vordefinierte **Issue-Templates**, um den übers
 - **Problem melden**: Während der Entwicklung oder Nutzung der App ist aufgefallen, das etwas nicht wie vorgesehen funktioniert. Der Issue wird automatisch mit <GithubBadge background="#FBCA04" color="black">invalid</GithubBadge> gelabeled.
 - **Neues Feature:** Ein Vorschlag für ein neues Feature, das es bisher so noch nicht in der App gibt oder das ein bestehendes Feature erweitert. Der Issue wird automatisch mit <GithubBadge background="#a2eeef" color="black">enhancement</GithubBadge> gelabeled.
 - **Erweiterung der Dokumentation:** Ein fertiges Feature soll in dieser Dokumentation erklärt werden. Der Issue wird automatisch mit <GithubBadge background="#25C19F" color="black">docs-wanted</GithubBadge> gelabeled.
-- **Security Vulnerability Tracking**: [Dependabot](./workflows#dependabot) hat eine Security Vulnerability gefunden. In diesem Issue wird getracked, was getan werden kann, um die Vulnerabilty zu beseitigen. Der Issue wird automatisch mit <GithubBadge background="#FBCA04" color="black">security</GithubBadge> gelabeled.
+- **Security Vulnerability Tracking**: Dependabot hat eine Security Vulnerability gefunden. In diesem Issue wird getracked, was getan werden kann, um die Vulnerabilty zu beseitigen. Der Issue wird automatisch mit <GithubBadge background="#FBCA04" color="black">security</GithubBadge> gelabeled.
 
 :::tip
 

--- a/apps/docs/docs/40-github-management/workflows.mdx
+++ b/apps/docs/docs/40-github-management/workflows.mdx
@@ -5,7 +5,7 @@
 ### Pull Request Labeler {#labeler}
 
 Der Workflow "Pull Request Labeler" (`.github/workflows/pr_labeler.yml`) nutzt die GitHub Action [Labeler](https://github.com/marketplace/actions/labeler).
-Der Workflow labled neue Pull Requests automatisch basierend auf den geänderten Dateien mit <GithubBadge color="black" borderColor="black">apps/</GithubBadge> und <GithubBadge color="black" background="#F0B9F8">packages/</GithubBadge> Labels.
+Der Workflow labled neue Pull Requests automatisch basierend auf den geänderten Dateien mit <GithubBadge color="black" borderColor="black" background="white">apps/</GithubBadge> und <GithubBadge color="black" background="#F0B9F8">packages/</GithubBadge> Labels.
 Damit dieses Labeling korrekt funktioniert müssen die einzelnen Labels in der Konfigurationsdatei `.github/labeler.yml` zu den zugehörigen Dateipfaden zugeordnet werden.
 
 ```yaml title=".github/workflows/pr_labeler.yml"

--- a/apps/docs/docs/40-github-management/workflows.mdx
+++ b/apps/docs/docs/40-github-management/workflows.mdx
@@ -30,7 +30,6 @@ jobs:
 ```yaml title=".github/labeler.yml"
 
 # This file serves as configuration file for the labeler Workflow (.github/workflows/pr_labeler.yml)
-# Labels for Repo-Root (Turborepo Administration)
 
 # Labels for Github Health Files
 
@@ -48,15 +47,13 @@ apps/northware-cockpit:
   - changed-files:
       - any-glob-to-any-file: apps/northware-cockpit/**
 
-...
-
 # Labels for pakages/* changes
 
 packages/auth:
   - changed-files:
       - any-glob-to-any-file: packages/auth/**
 
-packages/database:
+packages/database and api:
   - changed-files:
       - any-glob-to-any-file: packages/database/**
 
@@ -86,15 +83,15 @@ Die Workflows sind nicht mit klassischen GitHub Actions sondern über das [integ
 
 Der Workflow **Turborepo CI** (`.github/workflows/turborepo-ci.yml`) wird immer dann ausgelöst, wenn Code auf den `main` Branch gepusht wird oder ein neuer Pull Request eröffnet oder aktualisiert wird.
 
-Der Workflow nutzt den vorliegenden Code und installiert das Projekt in einer Node.js Umgebung mit `pnpm`.
-Mit `pnpm build --affected` werden die von der Änderung betroffenen Code-Teile gebaut. 
-Mit `pnpm lint --affected` werden **Lint-Tests** des betroffenen Codes ausgeführt.
+- Der Workflow nutzt den vorliegenden Code und installiert das Projekt in einer Node.js Umgebung mit `pnpm`.
+- Mit `pnpm build --affected` werden die von der Änderung betroffenen Code-Teile gebaut.
+- Mit `pnpm lint:ci` werden die von der Änderung betroffenen Code-Teile mit [Biome](/General/formatting) überprüft.
 
 Sollte es während dieses Workflows zu Problemen kommen, wird der Workflow abgebrochen.
 
 :::info Local CI
 
-Der Turborepo CI-Workflow durchläuft bei jedem Pull Request und bei jedem Merge die Schritte `pnpm turbo build --affected` und `pnpm turbo run lint --affected`. 
+Der Turborepo CI-Workflow durchläuft bei jedem Pull Request und bei jedem Merge die Schritte `pnpm turbo build --affected` und `pnpm turbo run lint:ci`. 
 Damit diese Schritte nicht immer erst gemacht werden, wenn alles fertig ist lässt sich dieser Ablauf mit `pnpm localci` auch lokal abbilden, damit Fehler schon vor dem CI-Durchlauf auffallen.
 
 :::
@@ -103,7 +100,7 @@ Damit diese Schritte nicht immer erst gemacht werden, wenn alles fertig ist läs
 
 Der Workflow **autofix.ci** (.github/workflows/autofix.yml) wird immer dann ausgeführt, wenn ein neuer Pull Request hinzugefügt oder geändert wurde.
 
-Innerhalb des Workflows wird das Projekt vollständig gebaut, der vorhandene Code wird formatiert.
+Innerhalb des Workflows wird das Projekt vollständig gebaut, der vorhandene Code wird mit `pnpm format:root` formatiert.
 Wenn durch den Durchlauf des Workflows Änderungen am Code vorgenommen wurden, werden diese Code Fixes auf den vorhandenen Pull Request commitet.
 
 **Dieser Commit unterbricht nun alle laufenden Workflows.** Diese Workflows scheitern. Anschließend starten alle vorgesehenen Workflows wieder von neuem.

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "extends": ["ultracite"],
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "defaultBranch": "main"
+  },
   "javascript": {
     "globals": ["React"]
   },

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
     "build": "turbo build",
     "lint": "turbo lint",
     "lint:root": "ultracite lint",
+    "lint:ci": "biome ci ./",
     "format": "turbo format",
     "format:root": "ultracite format",
-    "localci": "turbo build lint:root --affected",
+    "localci": "turbo build lint:ci --affected",
     "commit": "commit",
     "tsc-check": "turbo tsc-check",
     "tsc-check:root": "tsc --noEmit"

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,7 @@
       "dependsOn": ["^lint"]
     },
     "//#lint:root": {},
+    "//#lint:ci": {},
     "format": {
       "dependsOn": ["^format"]
     },


### PR DESCRIPTION
## Beschreibung

Es ist jetzt dokumentiert, wie Biome und Ultracite in dem Projekt verwendet werden. Die Workflow Dokumentation ist entsprechend angepasst und Referenzen zu @northware/eslint-config wurden aus den Docs entfernt.

### Referenzen

Dieser Pull Request löst den Issue #269

### Andere Anpassungen

- Biome ist jetzt so konfiguriert, dass es mit Git interagieren kann. Der neue Command lint:ci soll den Turborepo CI Workflow und localci verbessern
- Die Workflows autofix.ci und Turborepo CI arbeiten jetzt mit abgeänderten Biome Commands
- In der Beschreibung zum Issue Template Security Vulnerability Tracking hatte ich zu den Workflow-Docs von Dependabot verlinkt. Dieser Abschnitt wurde entfernt und durch Renovate ersetzt. Es bleibt aber dabei, dass Dependabot dafür zuständig ist, Security Vulnerabilities aufzuspüren. Daher wurde nur die Verlinkung entfernt.
- Das Helper GitHubBadge für `apps/*` hat jetzt immer einen weißen Hintergrund, einen schwarzen Rahmen und eine schwarze Textfarbe. So ist der Badge auch im Darkmode gut erkennbar.
