### PR TITLE
feat(ui): Use cva in the Headline Component

### DIFF
--- a/packages/ui/src/components/base/headline.tsx
+++ b/packages/ui/src/components/base/headline.tsx
@@ -1,12 +1,26 @@
 import { cn } from '@northware/ui/lib/utils';
+import { cva } from 'class-variance-authority';
 import type { HTMLAttributes, ReactNode } from 'react';
 
 interface HeadlineProps extends HTMLAttributes<HTMLHeadingElement> {
   children: ReactNode;
-  level: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'title';
+  level: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
-// TODO: über cva steuern?
-const basicClasses = 'scroll-m-20 tracking-tight';
+
+const headlineClasses = cva('scroll-m-20 tracking-tight', {
+  variants: {
+    level: {
+      h1: 'mb-3 font-bold text-4xl',
+      h2: 'font-semibold text-3xl first:mt-0',
+      h3: 'font-semibold text-2xl',
+      h4: 'font-semibold text-xl',
+      h5: 'font-medium text-lg',
+      h6: 'font-medium text-base',
+      unknown: 'font-bold text-4xl text-warning',
+    },
+  },
+  defaultVariants: { level: 'unknown' },
+});
 
 export function Headline({
   children,
@@ -17,65 +31,46 @@ export function Headline({
   switch (level) {
     case 'h1':
       return (
-        <h1
-          className={cn('mb-3 font-bold text-4xl', basicClasses, className)}
-          {...props}
-        >
+        <h1 className={cn(headlineClasses({ level }), className)} {...props}>
           {children}
         </h1>
       );
     case 'h2':
       return (
-        <h2
-          className={cn(
-            'font-semibold text-3xl first:mt-0',
-            basicClasses,
-            className
-          )}
-          {...props}
-        >
+        <h2 className={cn(headlineClasses({ level }), className)} {...props}>
           {children}
         </h2>
       );
     case 'h3':
       return (
-        <h3
-          className={cn('font-semibold text-2xl', basicClasses, className)}
-          {...props}
-        >
+        <h3 className={cn(headlineClasses({ level }), className)} {...props}>
           {children}
         </h3>
       );
     case 'h4':
       return (
-        <h4
-          className={cn('font-semibold text-xl', basicClasses, className)}
-          {...props}
-        >
+        <h4 className={cn(headlineClasses({ level }), className)} {...props}>
           {children}
         </h4>
       );
     case 'h5':
       return (
-        <h5
-          className={cn('font-medium text-lg', basicClasses, className)}
-          {...props}
-        >
+        <h5 className={cn(headlineClasses({ level }), className)} {...props}>
           {children}
         </h5>
       );
     case 'h6':
       return (
-        <h5
-          className={cn('font-medium text-base', basicClasses, className)}
-          {...props}
-        >
+        <h6 className={cn(headlineClasses({ level }), className)} {...props}>
           {children}
-        </h5>
+        </h6>
       );
     default:
       return (
-        <p className="font-bold text-4xl text-warning">
+        <p
+          className={cn(headlineClasses({ level: 'unknown' }), className)}
+          {...props}
+        >
           Achtung das Headline-Level {level} wird noch nicht unterstützt.
         </p>
       );


### PR DESCRIPTION
## Beschreibung

Die Headline-Komponente nutzt zum Rendern unterschiedlicher Headline-Stylings jetzt cva. Die switch/case Abfrage bleibt auch weiterhin bestehen, damit semantisch die richtigen HTML-Elemente (h1 bis h6) gerendert werden.