### PR TITLE
docs(mixed): Fix Packages README links

### DIFF
--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -2,4 +2,4 @@
 
 Provides the Authentification and Login Functionality for Northware with Clerk
 
-**[Read more on the Docs](https://ncsnorthware.mintlify.app/packages/auth)**
+**[Read the Docs on @northware/auth](https://ncsnorthware.mintlify.app/packages/auth)**

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -2,4 +2,4 @@
 
 `@northware/database` is used to connect any app inside this project to the Neon Databse and to define the Database Schema with Drizzle.
 
-**[@northware/database on Northware Docs](https://ncs-northware.github.io/northware/Packages/database)**
+**[Read the docs on @northware/database](https://ncsnorthware.mintlify.app/packages/database)**

--- a/packages/service-config/README.md
+++ b/packages/service-config/README.md
@@ -2,4 +2,4 @@
 
 Helper Functions to control which Service of the Northware Suite is currently running.
 
-**[Read more in the Docs](https://ncsnorthware.mintlify.app/packages/service-config)**
+**[Read the docs on @northware/service-config](https://ncsnorthware.mintlify.app/packages/service-config)**

--- a/packages/tailwind-config/README.md
+++ b/packages/tailwind-config/README.md
@@ -2,4 +2,4 @@
 
 The package `@northware/tailwind-config` exports a `tailwind.config.ts` file. This configuration file can be imported into apps and packages that use Tailwind as a preset in the configuration file of the app/package.
 
-[Read Full Documentation on GitHub Pages](https://ncs-northware.github.io/northware/Packages/tailwind-config)
+[Read the docs on @northware/tailwind-config](https://ncs-northware.github.io/northware/Packages/tailwind-config)

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -19,3 +19,5 @@ import "./globals.css";
 // Stylesheet from @northware/ui
 import "@northware/ui/styles.css";
 ```
+
+[Read the full documentation on @northware/ui](https://ncsnorthware.mintlify.app/ui/introduction)


### PR DESCRIPTION
Die Readme's der Packages verweisen jetzt auf die neuen Mintlify Docs.

fix #278 