### PR TITLE
fix(ui): Mark tw-animate-css as devDependency

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -40,7 +40,6 @@
     "next-themes": "^0.4.6",
     "react-hook-form": "^7.56.0",
     "tailwind-merge": "^3.2.0",
-    "tw-animate-css": "^1.2.7",
     "zod": "^3.24.3"
   },
   "devDependencies": {
@@ -48,6 +47,7 @@
     "@svgr/cli": "^8.1.0",
     "@tailwindcss/postcss": "^4.1.4",
     "@types/react": "^19.1.2",
-    "tailwindcss": "^4.1.4"
+    "tailwindcss": "^4.1.4",
+    "tw-animate-css": "^1.2.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,9 +271,6 @@ importers:
       tailwind-merge:
         specifier: ^3.2.0
         version: 3.2.0
-      tw-animate-css:
-        specifier: ^1.2.7
-        version: 1.2.7
       zod:
         specifier: ^3.24.3
         version: 3.24.3
@@ -293,6 +290,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.4
         version: 4.1.4
+      tw-animate-css:
+        specifier: ^1.2.7
+        version: 1.2.7
 
 packages:
 


### PR DESCRIPTION
## Beschreibung

In https://github.com/shadcn-ui/ui/pull/6985 wurde `tw-animate-css` als devDependency markiert. Diese Änderung möchte ich auch auf `@northware/ui` anwenden.

## Referenzen

fix #400