### PR TITLE
fix(docs): Use Northware UI URL on netlify

### DIFF
--- a/apps/docs/mint.json
+++ b/apps/docs/mint.json
@@ -45,7 +45,7 @@
     },
     {
       "name": "Northware UI",
-      "url": "http://localhost:40181",
+      "url": "https://northware-storybook.netlify.app",
       "icon": "react"
     }
   ],


### PR DESCRIPTION
Der Anchor zur Dokumentation verlinkt jetzt auf das Production Deployment vom Storybook auf Netlify.
