### PR TITLE
fix(ui): Review position of MobileNav Dialog

### DIFF
--- a/packages/ui/components/menu/main-nav.tsx
+++ b/packages/ui/components/menu/main-nav.tsx
@@ -28,11 +28,10 @@ import Link from "next/link";
 export async function MainNav({ service }: { service: ServiceType }) {
   // TODO: Add NavMenu Rendering based on permissionKey
   const user = await currentUser();
-  console.log(user);
   const menuItems = await menuData(service, user?.id);
   // Die Hauptnavigation incl. Branding auf Desktops
   return (
-    <div className="container hidden md:block">
+    <div className="container hidden pt-1 md:block">
       <MetaNav service={service} user={user} />
       <div className="flex bg-background/95 py-2">
         <div className="flex gap-4">

--- a/packages/ui/components/menu/mobile-nav.tsx
+++ b/packages/ui/components/menu/mobile-nav.tsx
@@ -42,7 +42,7 @@ export async function MobileNav({ service }: { service: ServiceType }) {
           </DialogTrigger>
           <DialogContent
             aria-describedby="Hauptmenü"
-            className="data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 flex flex-col border-b"
+            className="data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top translate-0 top-0 left-0 flex w-full max-w-full flex-col border-b"
           >
             <DialogTitle className="font-semibold">
               <Link href="/">


### PR DESCRIPTION
Der `DialogContent` im `MobileNav` hatte Tailwind-Klassen, die die Position des Dialogs falsch definiert hatten. Jetzt wurde die Position so angepasst, dass der `DialogContent` der `MobileNav` wieder oben und über die ganze Breite des sichtbaren Bildschirms angezeigt wird.

fix #368