### PR TITLE
fix(gh-management): Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
 ## Beschreibung
 
 ### Referenzen
-
-Dieser Pull Request löst den Issue #


### PR DESCRIPTION
Wenn es Referenzen zu Pull Requests gibt, sollen diese zukünftig mit den GitHub Trigger-Worten angegben werden. Es ist dann kein besonderer Satz dafür notwendig.

