### PR TITLE
fix(cockpit): Delete User with Roles and Permissions on Page Level

### DIFF
--- a/apps/cockpit/src/app/admin/user/[userId]/layout.tsx
+++ b/apps/cockpit/src/app/admin/user/[userId]/layout.tsx
@@ -22,7 +22,10 @@ export default async function EditUserLayout({
         { label: "Admin Panel", href: "/admin" },
         { label: "Benutzerverwaltung", href: "/admin/user" },
         {
-          label: user?.fullName || "Benutzer",
+          label:
+            user?.fullName ||
+            user?.emailAddresses[0].emailAddress ||
+            "Benutzer",
           href: `/admin/user/${userId}`,
           active: true,
         },

--- a/apps/cockpit/src/app/admin/user/[userId]/page.tsx
+++ b/apps/cockpit/src/app/admin/user/[userId]/page.tsx
@@ -1,6 +1,7 @@
 import {
   UpdatePasswordFormDialog,
   UpdateUserForm,
+  UserDeleteButton,
   UserEmailList,
 } from "@/components/user-forms";
 import { getSingleUser } from "@/lib/user-actions";
@@ -29,6 +30,7 @@ export default async function Page({
           </p>
         </div>
         <UpdatePasswordFormDialog id={user?.id} />
+        <UserDeleteButton userId={user?.id || ""} mode="page" />
       </div>
       <UpdateUserForm user={user} />
       <Headline level="h2">E-Mail Adressen</Headline>

--- a/apps/cockpit/src/components/user-forms.tsx
+++ b/apps/cockpit/src/components/user-forms.tsx
@@ -94,6 +94,7 @@ import {
   TrashIcon,
   TriangleAlertIcon,
 } from "@northware/ui/icons/lucide";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 
@@ -565,12 +566,17 @@ export function UpdatePasswordFormDialog({ id }: { id?: string }) {
   );
 }
 
-export function UserDeleteButton({ userId }: { userId: string }) {
+export function UserDeleteButton({
+  userId,
+  mode = "list",
+}: { userId: string; mode?: "list" | "page" }) {
+  const router = useRouter();
   const [errors, setErrors] = useState<string[]>([]);
   async function submitUserDeletion() {
     setErrors([]); // Fehler zurücksetzen
     try {
       await deleteUser(userId);
+      router.push("/admin/user");
       toast.success("Der Benutzer wurde gelöscht.");
     } catch (err) {
       setErrors(parseErrorMessages(err));
@@ -582,8 +588,12 @@ export function UserDeleteButton({ userId }: { userId: string }) {
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
-        <Button variant="ghostDanger" size="icon">
-          <TrashIcon className="size-4" />
+        <Button
+          variant={mode === "page" ? "danger" : "ghostDanger"}
+          size={mode === "page" ? "sm" : "icon"}
+        >
+          <TrashIcon />
+          {mode === "page" && <span>Benutzer löschen</span>}
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>


### PR DESCRIPTION
## Beschreibung

Die Funktion `deleteUser` hat eine Logik erhalten, mit der zuerst alle Rollen und Berechtigungen des Benutzers aus der Datenbank gelöscht werden, bevor der Clerk User gelöscht wird. Außerdem lässt sich der Benutzer nun auch von der Detail-Page aus löschen. Dies erforderte auch eine Anpassung der `UserDeleteButton` Komponente. Sollte ein Nutzer mal keinen Vor- und/oder Nachnamen haben, wird nun die E-Mail-Adresse im Breadcrumb angezeigt.
