### PR TITLE
fix(root): Add subject-max-lenght rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,3 @@
 > The Northware project (including Northware Cockpit, Northware Trader, Northware Finance, Northware Docs, and all apps and packages contained within this repository) is intended for demonstration and educational purposes only. This project was not developed for productive use in the real world (business or otherwise). The code may be partially or completely insecure and/or unstable and is in no way legally compliant.
 >
 > Any confidential data should be insertet through an external database and is completely fictional. If you find data within the codebase that does not seem to serve the basic structure of the project, please [report by an issue](https://github.com/ncs-northware/northware/issues/new). Even if you find parts of the code that do not seem to be intended for the public despite our previous review (such as access data or other backdoors), please report them as an issue to the repository owner. Thank you!
-
-Test

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@
 > The Northware project (including Northware Cockpit, Northware Trader, Northware Finance, Northware Docs, and all apps and packages contained within this repository) is intended for demonstration and educational purposes only. This project was not developed for productive use in the real world (business or otherwise). The code may be partially or completely insecure and/or unstable and is in no way legally compliant.
 >
 > Any confidential data should be insertet through an external database and is completely fictional. If you find data within the codebase that does not seem to serve the basic structure of the project, please [report by an issue](https://github.com/ncs-northware/northware/issues/new). Even if you find parts of the code that do not seem to be intended for the public despite our previous review (such as access data or other backdoors), please report them as an issue to the repository owner. Thank you!
+
+Test

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -9,7 +9,8 @@ const Configuration: UserConfig = {
       "always",
       ["chore", "docs", "feat", "fix", "revert"],
     ],
-    "scope-max-length": [RuleConfigSeverity.Warning, "always", 40],
+    "scope-max-length": [RuleConfigSeverity.Warning, "always", 10],
+    "subject-max-length": [RuleConfigSeverity.Warning, "always", 45],
   },
   ignores: [
     (commitMessage) => {


### PR DESCRIPTION
## Beschreibung

Das `subject` von `commitlint` darf jetzt nur noch 45 Zeichen lang sein. So passt dann der komplette Commit (mit Type, Scope und Subject) in den PR-Title auf GitHub. Der `scope` darf dabei maximal 10 Zeichen lang sein.
