### PR TITLE
fix(management): Remove Renovate Shedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,6 @@
   "semanticCommits": "enabled",
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
-  "schedule": ["* 0-3 1 * *"],
   "timezone": "Europe/Amsterdam",
   "vulnerabilityAlerts": {
     "labels": ["security", "dependencies"]


### PR DESCRIPTION
Da die Dependency Updates über Renovate größtenteils automatisch gemerged werden, braucht es keinen speziellen schedule mehr. Zukünftig gilt daher der Standard "at any time".
