### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/turborepo-ci.yml
+++ b/.github/workflows/turborepo-ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     name: Build and Lint


### PR DESCRIPTION
Potential fix for [https://github.com/ncs-northware/northware/security/code-scanning/2](https://github.com/ncs-northware/northware/security/code-scanning/2)

To address the issue, an explicit `permissions` block should be added to the workflow. Since the workflow does not require write permissions, we can set the `contents: read` permission to allow read-only access to repository contents. This permission is sufficient for the current workflow tasks, such as checking out code and running build/lint operations.

Changes will be made to the `.github/workflows/turborepo-ci.yml` file:
1. Add a `permissions` block at the root level of the workflow, applying to all jobs by default.
2. Alternatively, if specific jobs require different permissions in the future, the `permissions` block can be added within each job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
