### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tsc-check.yml
+++ b/.github/workflows/tsc-check.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   tsc:
     name: TypeScript Syntax Checks


### PR DESCRIPTION
Potential fix for [https://github.com/ncs-northware/northware/security/code-scanning/1](https://github.com/ncs-northware/northware/security/code-scanning/1)

To address the issue, the `permissions` key should be added at the root level of the workflow file to restrict the permissions of the `GITHUB_TOKEN`. Since this workflow only performs TypeScript syntax checks, it does not require write permissions. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents without granting unnecessary write privileges.

This change ensures that the workflow operates under the principle of least privilege, reducing the risk of unintended repository modifications or security vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
