### PR TITLE
fix(cockpit): Resolve zod import

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -21,7 +21,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.60.0",
-    "zod": "^3.25.76"
+    "zod": "^4.0.2"
   },
   "devDependencies": {
     "@northware/tsconfig": "workspace:*",

--- a/apps/cockpit/src/lib/rbac-schema.ts
+++ b/apps/cockpit/src/lib/rbac-schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import { z } from "zod";
 
 /************** User Form Schema  **************************************************************/
 
@@ -36,7 +36,9 @@ export const UpdateUserFromSchema = z.object({
 export type TUpdateUserFormSchema = z.infer<typeof UpdateUserFromSchema>;
 
 export const CreateEMailAddressFormSchema = z.object({
-  emailAddress: z.email(),
+  emailAddress: z.email({
+    error: "Bitte geben Sie eine gültige E-Mail-Adresse ein.",
+  }),
   verified: z.boolean().default(true).optional(),
   primary: z.boolean().default(false).optional(),
 });
@@ -111,28 +113,24 @@ export type TRoleDetailFormSchema = z.infer<typeof RoleDetailFormSchema>;
 
 export const PermissionDetailFormSchema = z.object({
   recordId: z.number(),
-  permissionKey: z.union([
-    z.literal("all-access"),
-    z
-      .string()
-      .regex(
-        /^(all|cockpit|trader|finance)::([a-z0-9]+(?:-[a-z0-9]+)*)(?::([a-z0-9]+(?:-[a-z0-9]+)*))?\.(read|create|update|delete)$/,
-        "Ungültiges Format des Berechtigungssschlüssels. Erwartet wird app::feature:subfeature.permission"
-      ),
-  ]),
+  permissionKey: z
+    .string()
+    .regex(
+      /^(all|cockpit|trader|finance)::([a-z0-9]+(?:-[a-z0-9]+)*)(?::([a-z0-9]+(?:-[a-z0-9]+)*))?\.(read|create|update|delete)$/,
+      "Ungültiges Format des Berechtigungssschlüssels. Erwartet wird app::feature:subfeature.permission"
+    )
+    .or(z.literal("all-access")),
   permissionName: z.string(),
 });
 
 export const CreatePermissionDetailFormSchema = z.object({
-  permissionKey: z.union([
-    z.literal("all-access"),
-    z
-      .string()
-      .regex(
-        /^(cockpit|trader|finance)::([a-z0-9]+(?:-[a-z0-9]+)*)(?::([a-z0-9]+(?:-[a-z0-9]+)*))?\.(read|create|update|delete)$/,
-        "Ungültiges Format des Berechtigungssschlüssels. Erwartet wird app::feature:subfeature.permission"
-      ),
-  ]),
+  permissionKey: z
+    .string()
+    .regex(
+      /^(all|cockpit|trader|finance)::([a-z0-9]+(?:-[a-z0-9]+)*)(?::([a-z0-9]+(?:-[a-z0-9]+)*))?\.(read|create|update|delete)$/,
+      "Ungültiges Format des Berechtigungssschlüssels. Erwartet wird app::feature:subfeature.permission"
+    )
+    .or(z.literal("all-access")),
   permissionName: z.string(),
 });
 

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -15,7 +15,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.60.0",
-    "zod": "^3.25.76"
+    "zod": "^4.0.2"
   },
   "devDependencies": {
     "@northware/service-config": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -67,7 +67,7 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
-    "zod": "^3.25.75"
+    "zod": "^4.0.2"
   },
   "devDependencies": {
     "@northware/tsconfig": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^7.60.0
         version: 7.60.0(react@19.1.0)
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
       '@northware/tsconfig':
         specifier: workspace:*
@@ -118,8 +118,8 @@ importers:
         specifier: ^7.60.0
         version: 7.60.0(react@19.1.0)
       zod:
-        specifier: ^3.25.76
-        version: 3.25.76
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
       '@northware/service-config':
         specifier: workspace:*
@@ -356,8 +356,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod:
-        specifier: ^3.25.75
-        version: 3.25.75
+        specifier: ^4.0.2
+        version: 4.0.2
     devDependencies:
       '@northware/tsconfig':
         specifier: workspace:*
@@ -5935,11 +5935,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  zod@3.25.75:
-    resolution: {integrity: sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.0.2:
+    resolution: {integrity: sha512-X2niJNY54MGam4L6Kj0AxeedeDIi/E5QFW0On2faSX5J4/pfLk1tW+cRMIMoojnCavn/u5W/kX17e1CSGnKMxA==}
 
 snapshots:
 
@@ -11805,6 +11802,4 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  zod@3.25.75: {}
-
-  zod@3.25.76: {}
+  zod@4.0.2: {}


### PR DESCRIPTION
## Beschreibung

Seit `zod@4.0.0` wird `zod/v4` auch über den Standard-Auftruf `zod` bereitgestellt. Diese Veränderung wird nun angenommen. Außerdem wurden kleinere Schema-Anpassungen vorgenommen, um das richtige Verhalten in zod 4 zu erreichen.

### Referenzen

- #455 
- #497 
- #511 