### PR TITLE
fix(cockpit): Reset Dialog Form Values on Submit

### DIFF
--- a/apps/cockpit/src/components/role-forms.tsx
+++ b/apps/cockpit/src/components/role-forms.tsx
@@ -484,12 +484,22 @@ export function CreatePermissionDetails() {
       permissionName: "",
     },
   });
+
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      form.reset(); // Formular zurücksetzen, wenn Dialog geschlossen wird
+      setErrors([]); // Fehler auch zurücksetzen
+    }
+  };
+
   const onSubmit: SubmitHandler<TCreatePermissionDetailFormSchema> = async (
     data
   ) => {
     try {
       await createPermDetails(data);
       setOpen(false);
+      form.reset(); // Formular nach Submit zurücksetzen
       toast.success("Es wurde ein neuer Berechtigungsschlüssel hinzugefügt.");
     } catch (err) {
       setErrors(parseErrorMessages(err));
@@ -497,7 +507,7 @@ export function CreatePermissionDetails() {
   };
   return (
     // TODO: #542 Assistant um mehere Berechtigungen zu erstellen
-    <Dialog onOpenChange={setOpen} open={open}>
+    <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogTrigger asChild>
         <Button>
           <PlusIcon className="sm:hidden" />
@@ -563,7 +573,6 @@ export function CreatePermissionDetails() {
         </Form>
       </DialogContent>
     </Dialog>
-    // FIXME: Die Formularwerte müssen immer den aktuellen Daten entsprechen. Es sollte nicht dazu kommen, das die Formular-Daten eines anderen Eintrags gecached werden.
   );
 }
 
@@ -582,6 +591,19 @@ export function UpdatePermissionDetails({
       permissionName: permissionDetails.permissionName || "",
     },
   });
+
+  // Formularwerte zurücksetzen, wenn Dialog geöffnet wird oder permissionDetails sich ändern
+  useEffect(() => {
+    if (open) {
+      form.reset({
+        recordId: permissionDetails.recordId,
+        permissionKey: permissionDetails.permissionKey,
+        permissionName: permissionDetails.permissionName || "",
+      });
+      setErrors([]);
+    }
+  }, [open, permissionDetails, form.reset]);
+
   const onSubmit: SubmitHandler<TPermissionDetailFormSchema> = async (data) => {
     try {
       await updatePermDetails(data);
@@ -665,7 +687,6 @@ export function UpdatePermissionDetails({
       </DialogContent>
     </Dialog>
   );
-  // FIXME: Die Formularwerte müssen immer den aktuellen Daten entsprechen. Es sollte nicht dazu kommen, das die Formular-Daten eines anderen Eintrags gecached werden.
 }
 
 export function PermissionDeleteButton({

--- a/apps/cockpit/src/components/user-forms.tsx
+++ b/apps/cockpit/src/components/user-forms.tsx
@@ -347,11 +347,20 @@ function CreateEmailFormDialog({ userId }: { userId?: string }) {
     },
   });
 
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      form.reset();
+      setErrors([]);
+    }
+  };
+
   async function onSubmit(values: TCreateEMailAddressFormSchema) {
     setErrors([]); // Fehler zurücksetzen
     try {
       await createEmailAddress(values, userId);
       setOpen(false);
+      form.reset();
       toast.success("Die E-Mail Adresse wurde hinzugefügt.");
     } catch (err) {
       setErrors(parseErrorMessages(err));
@@ -359,7 +368,7 @@ function CreateEmailFormDialog({ userId }: { userId?: string }) {
   }
 
   return (
-    <Dialog onOpenChange={setOpen} open={open}>
+    <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogTrigger asChild>
         <Button size="sm" variant="outline">
           E-Mail Adresse hinzufügen
@@ -458,11 +467,20 @@ export function UpdatePasswordFormDialog({ id }: { id?: string }) {
     },
   });
 
+  const handleOpenChange = (isOpen: boolean) => {
+    setOpen(isOpen);
+    if (!isOpen) {
+      form.reset(); // Formular zurücksetzen, wenn Dialog geschlossen wird
+      setErrors([]); // Fehler auch zurücksetzen
+    }
+  };
+
   const onSubmit: SubmitHandler<TUpdatePasswordFormSchema> = async (data) => {
     setErrors([]); // Fehler zurücksetzen
     try {
       await updatePassword(id, data);
       setOpen(false);
+      form.reset();
       toast.success("Das Passwort wurde gespeichert.");
     } catch (err) {
       setErrors(parseErrorMessages(err));
@@ -470,7 +488,7 @@ export function UpdatePasswordFormDialog({ id }: { id?: string }) {
   };
 
   return (
-    <Dialog onOpenChange={setOpen} open={open}>
+    <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogTrigger asChild>
         <Button size="sm" variant="outline">
           Passwort ändern


### PR DESCRIPTION
Die Komponenten CreatePermissionDetails, UpdatePermissionDetails und CreateEmailFormDialog nutzen jetzt die form.reset() Funktion von react-hook-form und eine custom handleOpenChange Funktionalität um zu gewährleisten, das die Dialog Forms immer nach dem Submit geleert werden bzw. die aktuellen Werte enthalten.
