### PR TITLE
fix(ui): Re-Add richColors to Toaster

### DIFF
--- a/packages/ui/components/general-provider.tsx
+++ b/packages/ui/components/general-provider.tsx
@@ -11,6 +11,6 @@ export const GeneralProvider = ({
 }: GeneralProviderProperties) => (
   <ThemeProvider {...properties}>
     <AuthProvider>{children}</AuthProvider>
-    <Toaster />
+    <Toaster richColors />
   </ThemeProvider>
 );


### PR DESCRIPTION
Da die Toaster-Komponente im GeneralProvider jetzt wieder den Property richColors verwendet, werden die verschiedenen Toaster-Varianten (Info, Success, Error, Warning) wieder mit Farben angezeigt.

fix #545
