### PR TITLE
feat(cockpit):Filterable Permission/Role UI

### DIFF
--- a/apps/cockpit/src/app/admin/role/[recordId]/page.tsx
+++ b/apps/cockpit/src/app/admin/role/[recordId]/page.tsx
@@ -39,7 +39,7 @@ export default async function Page({
   return (
     <SidebarLayout
       breadcrumbs={[
-        { label: "Amin Panel", href: "/admin" },
+        { label: "Admin Panel", href: "/admin" },
         { label: "Rollenverwaltung", href: "/admin/role" },
         {
           label: details?.role.roleName || "Rolle",

--- a/apps/cockpit/src/app/admin/user/[userId]/permissions/page.tsx
+++ b/apps/cockpit/src/app/admin/user/[userId]/permissions/page.tsx
@@ -25,7 +25,6 @@ export default async function Page({
         permissionsResponse={permissionList}
         userId={userId}
       />
-      {/* TODO: #539, #540 Dialogs für PermissionKeys bearbeiten und erstellen, Berechtigungen gruppieren?, Berechtigungen in einem grid darstellen? */}
     </PermissionProvider>
   );
 }

--- a/apps/cockpit/src/app/admin/user/[userId]/roles/page.tsx
+++ b/apps/cockpit/src/app/admin/user/[userId]/roles/page.tsx
@@ -28,7 +28,6 @@ export default async function Page({
         userId={userId}
         userRolesResponse={userRoles}
       />
-      {/* TODO: #539, #540 Dialogs für Rollen bearbeiten und erstellen, Rollen gruppieren?, Rollen in einem grid darstellen?  */}
     </PermissionProvider>
   );
 }

--- a/apps/cockpit/src/components/role-forms.tsx
+++ b/apps/cockpit/src/components/role-forms.tsx
@@ -2,6 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertIcon, AlertWrapper } from "@northware/ui/components/custom-alert";
+import { Headline } from "@northware/ui/components/headline";
 import {
   AlertDescription,
   AlertTitle,
@@ -39,7 +40,7 @@ import { Switch } from "@northware/ui/components/ui-registry/switch";
 import { EditIcon, PlusIcon, TrashIcon } from "@northware/ui/icons/lucide";
 import { toast } from "@northware/ui/lib/utils";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import {
   CreatePermissionDetailFormSchema,
@@ -73,6 +74,8 @@ export function CreateRoleForm({
 }: {
   permissionsResponse: TPermissionListResponse;
 }) {
+  const [filterValue, setFilterValue] = useState<string>("");
+
   const form = useForm<TCreateRoleFormData>({
     resolver: zodResolver(CreateRoleFormSchema),
     defaultValues: {
@@ -97,13 +100,26 @@ export function CreateRoleForm({
     }
   };
 
+  const filteredPermissions = permissionsResponse.permissionList.filter(
+    (perm) => {
+      if (!filterValue) {
+        return true;
+      }
+      const v = filterValue.toLowerCase();
+      return (
+        perm.permissionName?.toLowerCase().includes(v) ||
+        perm.permissionKey?.toLowerCase().includes(v)
+      );
+    }
+  );
+
   return (
     <Form {...form}>
       <form
         className="flex flex-col gap-4"
         onSubmit={form.handleSubmit(onSubmit)}
       >
-        <div className="grid grid-cols-2 gap-4">
+        <div className="mb-5 grid grid-cols-2 gap-4">
           <FormField
             control={form.control}
             name="roleKey"
@@ -131,15 +147,18 @@ export function CreateRoleForm({
             )}
           />
         </div>
-
+        <Headline level="h2">Rollenberechtigungen vergeben</Headline>
         <div className="grid gap-4">
+          <PermissionFilter
+            filterValue={filterValue}
+            setFilterValue={setFilterValue}
+          />
           <FormField
             control={form.control}
             name="permissions"
             render={() => (
               <FormItem className="grid-cols-2">
-                {permissionsResponse.permissionList.map((perm) => (
-                  // TODO: #539 Gruppiert nach App
+                {filteredPermissions.map((perm) => (
                   <FormField
                     control={form.control}
                     key={perm.recordId}
@@ -295,6 +314,52 @@ export function UpdateRoleDetailForm({
   );
 }
 
+export function PermissionFilter({
+  setFilterValue,
+  filterValue,
+}: {
+  setFilterValue: Dispatch<SetStateAction<string>>;
+  filterValue: string;
+}) {
+  return (
+    <div className="flex flex-row gap-2">
+      <Input
+        onChange={(e) => setFilterValue(e.target.value)}
+        placeholder="Berechtigungen filtern"
+        value={filterValue}
+      />
+      <Button
+        onClick={() => setFilterValue("cockpit")}
+        type="button"
+        variant="secondary"
+      >
+        Northware Cockpit
+      </Button>
+      <Button
+        onClick={() => setFilterValue("finance")}
+        type="button"
+        variant="secondary"
+      >
+        Northware Finance
+      </Button>
+      <Button
+        onClick={() => setFilterValue("trader")}
+        type="button"
+        variant="secondary"
+      >
+        Northware Trader
+      </Button>
+      <Button
+        onClick={() => setFilterValue("")}
+        type="button"
+        variant="outline"
+      >
+        Zurücksetzen
+      </Button>
+    </div>
+  );
+}
+
 export function RolePermissionsForm({
   roleKey,
   permissionsResponse,
@@ -305,6 +370,7 @@ export function RolePermissionsForm({
   rolePermissions: string[];
 }) {
   const [errors, setErrors] = useState<string[]>([]);
+  const [filterValue, setFilterValue] = useState<string>(""); // Filter-Value State
 
   const form = useForm<TUpdatePermissionSchema>({
     resolver: zodResolver(UserUpdatePermissionsFormSchema),
@@ -335,16 +401,33 @@ export function RolePermissionsForm({
     }
   }
 
+  // Gefilterte Liste
+  const filteredPermissions = permissionsResponse.permissionList.filter(
+    (perm) => {
+      if (!filterValue) {
+        return true;
+      }
+      const v = filterValue.toLowerCase();
+      return (
+        perm.permissionName?.toLowerCase().includes(v) ||
+        perm.permissionKey?.toLowerCase().includes(v)
+      );
+    }
+  );
+
   return (
     <Form {...form}>
+      <PermissionFilter
+        filterValue={filterValue}
+        setFilterValue={setFilterValue}
+      />
       <form className="space-y-6" onSubmit={form.handleSubmit(onSubmit)}>
         <FormField
           control={form.control}
           name="permissions"
           render={() => (
             <FormItem className="grid-cols-2">
-              {permissionsResponse.permissionList.map((perm) => (
-                // TODO: #539 Gruppiert nach App
+              {filteredPermissions.map((perm) => (
                 <FormField
                   control={form.control}
                   key={perm.recordId}

--- a/apps/cockpit/src/components/role-forms.tsx
+++ b/apps/cockpit/src/components/role-forms.tsx
@@ -589,7 +589,6 @@ export function CreatePermissionDetails() {
     }
   };
   return (
-    // TODO: #542 Assistant um mehere Berechtigungen zu erstellen
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogTrigger asChild>
         <Button>

--- a/apps/cockpit/src/components/user-forms.tsx
+++ b/apps/cockpit/src/components/user-forms.tsx
@@ -74,6 +74,7 @@ import { toast } from "@northware/ui/lib/utils";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { type SubmitHandler, useForm } from "react-hook-form";
+import { PermissionFilter } from "@/components/role-forms";
 import {
   CreateEMailAddressFormSchema,
   parseErrorMessages,
@@ -796,6 +797,7 @@ export function UpdateUserPermissionsForm({
   userId,
 }: PermissionsFormProps) {
   const [errors, setErrors] = useState<string[]>([]);
+  const [filterValue, setFilterValue] = useState<string>("");
 
   const form = useForm<TUpdatePermissionSchema>({
     resolver: zodResolver(UserUpdatePermissionsFormSchema),
@@ -826,15 +828,32 @@ export function UpdateUserPermissionsForm({
     }
   }
 
+  const filteredPermissions = permissionsResponse.permissionList.filter(
+    (perm) => {
+      if (!filterValue) {
+        return true;
+      }
+      const v = filterValue.toLowerCase();
+      return (
+        perm.permissionName?.toLowerCase().includes(v) ||
+        perm.permissionKey?.toLowerCase().includes(v)
+      );
+    }
+  );
+
   return (
     <Form {...form}>
+      <PermissionFilter
+        filterValue={filterValue}
+        setFilterValue={setFilterValue}
+      />
       <form className="grid gap-4" onSubmit={form.handleSubmit(onSubmit)}>
         <FormField
           control={form.control}
           name="permissions"
           render={() => (
             <FormItem className="grid-cols-2">
-              {permissionsResponse.permissionList.map((perm) => (
+              {filteredPermissions.map((perm) => (
                 <FormField
                   control={form.control}
                   key={perm.recordId}


### PR DESCRIPTION
## Beschreibung

Die komplexen Listen von Permissions und Roles unter `/role/:id`, `/user/:id/roles` und `/user/:id/permissions` lassen sich jetzt über ein Input-Feld und spezielle Buttons filtern, damit der Nutzer nicht immer durch eine lange Liste scrollen muss, um eine Berechtigung/Rolle zu vergeben.

### Referenzen
- fix #539 
- #540 closed as not planned
- #542 closed as not planned