### PR TITLE
fix(action): Changesets AutoRelease Node bug potential fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Auto Release
+name: Changesets Auto Release
 
 on:
   push:
@@ -18,14 +18,16 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v5
+      
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js 20
         uses: actions/setup-node@v5
         with:
           node-version: 22.19.0
+          cache: pnpm
       
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
 
 
       - name: Install Dependencies


### PR DESCRIPTION
Der Workflow Changesets Auto Release funktioniert aktuell nicht, seitdem actions/setup-node@v5 (#566) genutzt wird. Dieser Bug hängt mit pnpm zusammen. Da alle anderen Workflows noch funktionieren, vermute ich das Problem darin, das erst pnpm und dann node installiert wurden. Diese Reihenfolge habe ich nun geändert und erhoffe mir einen fix.

