### PR TITLE
fix(cockpit/ui): force @hookform/resolvers@5.2.1

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -11,7 +11,7 @@
     "format": "ultracite format"
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.2.1",
+    "@hookform/resolvers": "<=5.2.1",
     "@northware/auth": "workspace:*",
     "@northware/database": "workspace:*",
     "@northware/ui": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@clerk/elements": "^0.23.63",
-    "@hookform/resolvers": "^5.2.1",
+    "@hookform/resolvers": "<=5.2.1",
     "@northware/auth": "workspace:*",
     "@northware/database": "workspace:",
     "@northware/service-config": "workspace:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,7 +42,7 @@ importers:
   apps/cockpit:
     dependencies:
       '@hookform/resolvers':
-        specifier: ^5.2.1
+        specifier: <=5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.1))
       '@northware/auth':
         specifier: workspace:*
@@ -246,7 +246,7 @@ importers:
         specifier: ^0.23.63
         version: 0.23.63(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(next@15.5.3(@babel/core@7.28.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@hookform/resolvers':
-        specifier: ^5.2.1
+        specifier: <=5.2.1
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.1))
       '@northware/auth':
         specifier: workspace:*


### PR DESCRIPTION
Since the build with @hookform/resolvers@5.2.2 fails currently, the version 5.2.1 is forced by the cockpit and @northware/ui. Tests on v5.2.2 will be made separately.

### Referenzen
https://github.com/react-hook-form/resolvers/releases/tag/v5.2.2
https://github.com/react-hook-form/resolvers/pull/803
