### PR TITLE
chore(formatting): Ignore new Version of ultracite

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@northware/tsconfig": "workspace:",
     "turbo": "^2.5.6",
     "typescript": "^5.9.2",
-    "ultracite": "5.3.10"
+    "ultracite": "<=5.3.10"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
       ultracite:
-        specifier: 5.3.10
+        specifier: <=5.3.10
         version: 5.3.10(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(typescript@5.9.2)
 
   apps/cockpit:


### PR DESCRIPTION
Damit der aktuelle Update-PR durchlaufen kann, wird das Update von ultracite vorübergehend ignoriert, da die Version 5.4 neue Regeln enthält, die erst übernommen werden müssen. Das Update auf ultracite@5.4 erfolgt dann gesondert.

related: #578
