### PR TITLE
fix(deps): update dependency ultracite to v5.4.5

### DIFF
--- a/apps/cockpit/package.json
+++ b/apps/cockpit/package.json
@@ -7,8 +7,8 @@
     "build": "next build",
     "start": "next start",
     "tsc-check": "tsc --noEmit",
-    "lint": "ultracite lint",
-    "format": "ultracite format"
+    "lint": "ultracite check",
+    "format": "ultracite fix"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/apps/cockpit/src/components/role-forms.tsx
+++ b/apps/cockpit/src/components/role-forms.tsx
@@ -177,8 +177,8 @@ export function CreateRoleForm({
                         <FormControl>
                           <Switch
                             checked={field.value.includes(perm.permissionKey)}
-                            onCheckedChange={(checked) => {
-                              return checked
+                            onCheckedChange={(checked) =>
+                              checked
                                 ? field.onChange([
                                     ...field.value,
                                     perm.permissionKey,
@@ -187,8 +187,8 @@ export function CreateRoleForm({
                                     field.value.filter(
                                       (value) => value !== perm.permissionKey
                                     )
-                                  );
-                            }}
+                                  )
+                            }
                           />
                         </FormControl>
                       </FormItem>
@@ -438,8 +438,8 @@ export function RolePermissionsForm({
                       <FormControl>
                         <Switch
                           checked={field.value.includes(perm.permissionKey)}
-                          onCheckedChange={(checked) => {
-                            return checked
+                          onCheckedChange={(checked) =>
+                            checked
                               ? field.onChange([
                                   ...field.value,
                                   perm.permissionKey,
@@ -448,8 +448,8 @@ export function RolePermissionsForm({
                                   field.value.filter(
                                     (value) => value !== perm.permissionKey
                                   )
-                                );
-                          }}
+                                )
+                          }
                         />
                       </FormControl>
                     </FormItem>

--- a/apps/cockpit/src/components/user-forms.tsx
+++ b/apps/cockpit/src/components/user-forms.tsx
@@ -852,8 +852,8 @@ export function UpdateUserRolesForm({
                           <FormControl>
                             <Switch
                               checked={field.value.includes(role.roleKey)}
-                              onCheckedChange={(checked) => {
-                                return checked
+                              onCheckedChange={(checked) =>
+                                checked
                                   ? field.onChange([
                                       ...field.value,
                                       role.roleKey,
@@ -862,8 +862,8 @@ export function UpdateUserRolesForm({
                                       field.value.filter(
                                         (value) => value !== role.roleKey
                                       )
-                                    );
-                              }}
+                                    )
+                              }
                             />
                           </FormControl>
                         </div>
@@ -999,8 +999,8 @@ export function CreateUserRolesForm({
                           <FormControl>
                             <Switch
                               checked={field.value.includes(role.roleKey)}
-                              onCheckedChange={(checked) => {
-                                return checked
+                              onCheckedChange={(checked) =>
+                                checked
                                   ? field.onChange([
                                       ...field.value,
                                       role.roleKey,
@@ -1009,8 +1009,8 @@ export function CreateUserRolesForm({
                                       field.value.filter(
                                         (value) => value !== role.roleKey
                                       )
-                                    );
-                              }}
+                                    )
+                              }
                             />
                           </FormControl>
                         </div>
@@ -1160,8 +1160,8 @@ export function UpdateUserPermissionsForm({
                       <FormControl>
                         <Switch
                           checked={field.value.includes(perm.permissionKey)}
-                          onCheckedChange={(checked) => {
-                            return checked
+                          onCheckedChange={(checked) =>
+                            checked
                               ? field.onChange([
                                   ...field.value,
                                   perm.permissionKey,
@@ -1170,8 +1170,8 @@ export function UpdateUserPermissionsForm({
                                   field.value.filter(
                                     (value) => value !== perm.permissionKey
                                   )
-                                );
-                          }}
+                                )
+                          }
                         />
                       </FormControl>
                     </FormItem>
@@ -1281,8 +1281,8 @@ export function CreateUserPermissionsForm({
                       <FormControl>
                         <Switch
                           checked={field.value.includes(perm.permissionKey)}
-                          onCheckedChange={(checked) => {
-                            return checked
+                          onCheckedChange={(checked) =>
+                            checked
                               ? field.onChange([
                                   ...field.value,
                                   perm.permissionKey,
@@ -1291,8 +1291,8 @@ export function CreateUserPermissionsForm({
                                   field.value.filter(
                                     (value) => value !== perm.permissionKey
                                   )
-                                );
-                          }}
+                                )
+                          }
                         />
                       </FormControl>
                     </FormItem>

--- a/apps/cockpit/src/lib/user-actions.ts
+++ b/apps/cockpit/src/lib/user-actions.ts
@@ -129,7 +129,7 @@ export const getSingleUser = cache(
     try {
       const client = await clerkClient();
       const response = await client.users.getUser(id);
-      const user_emailAddresses = response.emailAddresses
+      const userEmailAddresses = response.emailAddresses
         .map((email) => ({
           id: email.id,
           emailAddress: email.emailAddress,
@@ -153,7 +153,7 @@ export const getSingleUser = cache(
           lastName: response.lastName,
           fullName: response.fullName,
           username: response.username,
-          emailAddresses: user_emailAddresses,
+          emailAddresses: userEmailAddresses,
           primaryEmailAddressId: response.primaryEmailAddressId,
         },
       };

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -7,6 +7,7 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
     ...components,
+    // biome-ignore lint/style/useNamingConvention: JSX Component
     ChildDocs,
   };
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -5,8 +5,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --turbo --port 40180",
-    "format": "ultracite format",
-    "lint": "ultracite lint",
+    "format": "ultracite fix",
+    "lint": "ultracite check",
     "postinstall": "fumadocs-mdx",
     "start": "next start",
     "tsc-check": "tsc --noEmit"

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -3,7 +3,7 @@ import type { Preview } from "@storybook/nextjs";
 import React from "react";
 import "@northware/ui/css";
 import { ThemeProvider } from "@northware/ui/components/theme-provider";
-import { source_sans } from "@northware/ui/lib/fonts";
+import { SourceSans } from "@northware/ui/lib/fonts";
 import { withThemeByClassName } from "@storybook/addon-themes";
 
 const preview: Preview = {
@@ -34,35 +34,33 @@ const preview: Preview = {
   decorators: [
     withThemeByClassName({
       themes: {
-        CockpitLight: "CockpitLight",
-        CockpitDark: "CockpitDark",
-        FinanceLight: "FinanceLight",
-        FinanceDark: "FinanceDark",
-        TraderLight: "TraderLight",
-        TraderDark: "TraderDark",
+        cockpitLight: "CockpitLight",
+        cockpitDark: "CockpitDark",
+        financeLight: "FinanceLight",
+        financeDark: "FinanceDark",
+        traderLight: "TraderLight",
+        traderDark: "TraderDark",
       },
       defaultTheme: "CockpitLight",
     }),
-    (Story) => {
-      return (
-        <div className={`bg-background ${source_sans.variable} p-2 font-sans`}>
-          <ThemeProvider
-            defaultTheme="CockpitLight"
-            enableSystem={false}
-            themes={[
-              "CockpitLight",
-              "CockpitDark",
-              "FinanceLight",
-              "FinanceDark",
-              "TraderLight",
-              "TraderDark",
-            ]}
-          >
-            <Story />
-          </ThemeProvider>
-        </div>
-      );
-    },
+    (Story) => (
+      <div className={`bg-background ${SourceSans.variable} p-2 font-sans`}>
+        <ThemeProvider
+          defaultTheme="CockpitLight"
+          enableSystem={false}
+          themes={[
+            "CockpitLight",
+            "CockpitDark",
+            "FinanceLight",
+            "FinanceDark",
+            "TraderLight",
+            "TraderDark",
+          ]}
+        >
+          <Story />
+        </ThemeProvider>
+      </div>
+    ),
   ],
 };
 

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "storybook dev --no-open -p 40181",
     "build": "storybook build",
-    "tsc-check": "tsc --noEmit"
+    "tsc-check": "tsc --noEmit",
+    "format": "ultracite fix",
+    "lint": "ultracite check"
   },
   "dependencies": {
     "@northware/ui": "workspace:*",

--- a/apps/storybook/stories/components/base/button.stories.tsx
+++ b/apps/storybook/stories/components/base/button.stories.tsx
@@ -139,10 +139,8 @@ export const Disabled: Story = {
  * Wenn die `Button` Komponente andere Elemente umschließen soll kann der `asChild` Parameter verwendet werden.
  */
 
-export const AsChild = () => {
-  return (
-    <Button asChild>
-      <Link href="#">Link Child</Link>
-    </Button>
-  );
-};
+export const AsChild = () => (
+  <Button asChild>
+    <Link href="#">Link Child</Link>
+  </Button>
+);

--- a/apps/storybook/stories/components/base/headline.stories.tsx
+++ b/apps/storybook/stories/components/base/headline.stories.tsx
@@ -16,26 +16,26 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Überschrift1: Story = {
+export const Headline1: Story = {
   args: { level: "h1" },
 };
 
-export const Überschrift2: Story = {
+export const Headline2: Story = {
   args: { level: "h2" },
 };
 
-export const Überschrift3: Story = {
+export const Headline3: Story = {
   args: { level: "h3" },
 };
 
-export const Überschrift4: Story = {
+export const Headline4: Story = {
   args: { level: "h4" },
 };
 
-export const Überschrift5: Story = {
+export const Headline5: Story = {
   args: { level: "h5" },
 };
 
-export const Überschrift6: Story = {
+export const Headline6: Story = {
   args: { level: "h6" },
 };

--- a/apps/storybook/stories/components/form-parts/select.stories.tsx
+++ b/apps/storybook/stories/components/form-parts/select.stories.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/style/useNamingConvention: JSX Components */
 import {
   Select,
   SelectContent,

--- a/apps/storybook/stories/components/panels/data-table.stories.tsx
+++ b/apps/storybook/stories/components/panels/data-table.stories.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/style/useNamingConvention: JSX Components */
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import {
   DataTableColumnHeaderDemo,

--- a/apps/storybook/stories/northware-ui/app-usage.mdx
+++ b/apps/storybook/stories/northware-ui/app-usage.mdx
@@ -33,7 +33,7 @@ damit der User zwischen Light und DarkMode wechseln kann sowie `AuthProvider` vo
 ```tsx
 import "@northware/ui/css";
 import { GeneralProvider } from "@northware/ui/components/providers/general-provider";
-import { source_sans } from "@northware/ui/lib/fonts";
+import { SourceSans } from "@northware/ui/lib/fonts";
 ```
 
 Auch an dem Markup des Layouts müssen einige Veränderungen vorgenommen werden.
@@ -48,7 +48,7 @@ Die fertige `layout.tsx` der App könnte dann so aussehen:
 ```tsx
 import "@northware/ui/css";
 import { GeneralProvider } from "@northware/ui/components/providers/general-provider";
-import { source_sans } from "@northware/ui/lib/fonts";
+import { SourceSans } from "@northware/ui/lib/fonts";
 
 export const metadata = {
   title: {
@@ -64,7 +64,7 @@ export default function RootLayout({
 }>) {
   return (
     <html className="theme-cockpit" lang="de" suppressHydrationWarning>
-      <body className={`${source_sans.variable} font-sans`}>
+      <body className={`${SourceSans.variable} font-sans`}>
         <GeneralProvider>{children}</GeneralProvider>
       </body>
     </html>

--- a/apps/storybook/stories/northware-ui/lib.mdx
+++ b/apps/storybook/stories/northware-ui/lib.mdx
@@ -13,7 +13,7 @@ Unter dem Endpoint `@northware/ui/lib` werden unterstützende Funktionen bereitg
 
 Die Northware Apps verwenden die Schriftart [Source Sans 3](https://fonts.google.com/specimen/Source+Sans+3) von Google Fonts. 
 Die Schriftart muss über die `layout.tsx` der App importiert werden und es braucht dafür die Definition einer Variable.
-Diese Variable `source_sans` kann über `@northware/ui/lib/fonts` importiert werden.
+Diese Variable `SourceSans` kann über `@northware/ui/lib/fonts` importiert werden.
 
 - [Mehr zu der Nutzung in einer App](?path=/docs/northware-ui-verwendung-in-einer-app--docs#die-layouttsx)
 - [Über die Verwendung von Fonts in Next.js mit Tailwind CSS](https://nextjs.org/docs/app/building-your-application/optimizing/fonts#with-tailwind-css)

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,13 @@
   "linter": {
     "rules": {
       "performance": { "noBarrelFile": "warn" },
-      "style": { "noMagicNumbers": "info" }
+      "style": {
+        "noMagicNumbers": "info",
+        "useNamingConvention": {
+          "options": { "strictCase": false },
+          "level": "error"
+        }
+      }
     }
   },
   "files": {

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "commit": "commit",
     "dev": "turbo dev",
     "format": "turbo format",
-    "format:root": "ultracite format",
+    "format:root": "ultracite fix",
     "generate-icons": "cd packages/ui && pnpm generate-icons",
     "lint": "turbo lint",
     "lint:ci": "biome ci ./",
-    "lint:root": "ultracite lint",
+    "lint:root": "ultracite check",
     "localci": "turbo build lint:ci --affected",
     "tsc-check": "turbo tsc-check",
     "tsc-check:root": "tsc --noEmit"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@northware/tsconfig": "workspace:",
     "turbo": "^2.5.8",
     "typescript": "^5.9.2",
-    "ultracite": "<=5.3.10"
+    "ultracite": "5.4.5"
   },
   "engines": {
     "node": ">=18"

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "tsc-check": "tsc --noEmit",
-    "format": "ultracite format",
-    "lint": "ultracite lint"
+    "format": "ultracite fix",
+    "lint": "ultracite check"
   },
   "exports": {
     "./client": "./src/client.tsx",

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "tsc-check": "tsc --noEmit",
-    "lint": "ultracite lint",
-    "format": "ultracite format"
+    "lint": "ultracite check",
+    "format": "ultracite fix"
   },
   "exports": {
     "./connection": "./db-connect.ts",

--- a/packages/service-config/package.json
+++ b/packages/service-config/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "lint": "ultracite lint",
-    "format": "ultracite format"
+    "lint": "ultracite check",
+    "format": "ultracite fix"
   },
   "exports": {
     ".": "./src/index.ts"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "lint": "ultracite lint",
-    "format": "ultracite format"
+    "lint": "ultracite check",
+    "format": "ultracite fix"
   }
 }

--- a/packages/ui/components/auth.tsx
+++ b/packages/ui/components/auth.tsx
@@ -1,3 +1,4 @@
+/** biome-ignore-all lint/style/useNamingConvention: clerk internal names */
 "use client";
 
 import { SignIn, UserButton } from "@northware/auth/client";

--- a/packages/ui/components/data-table.tsx
+++ b/packages/ui/components/data-table.tsx
@@ -63,18 +63,16 @@ export function DataTableViewOptions<TData>({
             (column) =>
               typeof column.accessorFn !== "undefined" && column.getCanHide()
           )
-          .map((column) => {
-            return (
-              <DropdownMenuCheckboxItem
-                checked={column.getIsVisible()}
-                className="capitalize"
-                key={column.id}
-                onCheckedChange={(value) => column.toggleVisibility(!!value)}
-              >
-                {column.id}
-              </DropdownMenuCheckboxItem>
-            );
-          })}
+          .map((column) => (
+            <DropdownMenuCheckboxItem
+              checked={column.getIsVisible()}
+              className="capitalize"
+              key={column.id}
+              onCheckedChange={(value) => column.toggleVisibility(!!value)}
+            >
+              {column.id}
+            </DropdownMenuCheckboxItem>
+          ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/ui/lib/fonts.ts
+++ b/packages/ui/lib/fonts.ts
@@ -1,20 +1,20 @@
 import { cn } from "@northware/ui/lib/utils";
 import { Source_Code_Pro, Source_Sans_3 } from "next/font/google";
 
-export const source_sans = Source_Sans_3({
+export const SourceSans = Source_Sans_3({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-sourcesans",
 });
 
-export const source_code = Source_Code_Pro({
+export const SourceCode = Source_Code_Pro({
   subsets: ["latin"],
   display: "optional",
   variable: "--font-sourcecode",
 });
 
 export const fonts = cn(
-  source_sans.variable,
-  source_code.variable,
+  SourceSans.variable,
+  SourceCode.variable,
   "font-sans antialiased"
 );

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "tsc-check": "tsc --noEmit",
-    "format": "ultracite format",
-    "lint": "ultracite lint",
+    "format": "ultracite fix",
+    "lint": "ultracite check",
     "generate-icons": "svgr --config-file svgr.config.js --ignore-existing -- ./icons/assets"
   },
   "exports": {

--- a/packages/ui/svgr.config.js
+++ b/packages/ui/svgr.config.js
@@ -8,8 +8,7 @@ module.exports = {
   prettier: false,
   filenameCase: "kebab",
   titleProp: true,
-  template: (variables, { tpl }) => {
-    return tpl`
+  template: (variables, { tpl }) => tpl`
       ${variables.imports};
       
       ${variables.interfaces};
@@ -22,6 +21,5 @@ module.exports = {
       };
 
       ${variables.exports}
-    `;
-  },
+    `,
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^5.9.2
         version: 5.9.2
       ultracite:
-        specifier: <=5.3.10
-        version: 5.3.10(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(typescript@5.9.2)
+        specifier: 5.4.5
+        version: 5.4.5(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(typescript@5.9.2)
 
   apps/cockpit:
     dependencies:
@@ -3023,8 +3023,8 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@trpc/server@11.4.4':
-    resolution: {integrity: sha512-VkJb2xnb4rCynuwlCvgPBh5aM+Dco6fBBIo6lWAdJJRYVwtyE5bxNZBgUvRRz/cFSEAy0vmzLxF7aABDJfK5Rg==}
+  '@trpc/server@11.6.0':
+    resolution: {integrity: sha512-skTso0AWbOZck40jwNeYv++AMZXNWLUWdyk+pB5iVaYmEKTuEeMoPrEudR12VafbEU6tZa8HK3QhBfTYYHDCdg==}
     peerDependencies:
       typescript: '>=5.7.2'
 
@@ -3127,9 +3127,6 @@ packages:
 
   '@types/node@24.5.2':
     resolution: {integrity: sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==}
-
-  '@types/omelette@0.4.5':
-    resolution: {integrity: sha512-zUCJpVRwfMcZfkxSCGp73mgd3/xesvPz5tQJIORlfP/zkYEyp9KUfF7IP3RRjyZR3DwxkPs96/IFf70GmYZYHQ==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -5333,8 +5330,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nypm@0.6.1:
-    resolution: {integrity: sha512-hlacBiRiv1k9hZFiphPUkfSQ/ZfQzZDzC+8z0wL3lvDAOUu/2NnChkKuMoMjNur/9OpKuz2QsIeiPVN0xM5Q0w==}
+  nypm@0.6.2:
+    resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
@@ -5518,8 +5515,8 @@ packages:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
 
-  pkg-types@2.2.0:
-    resolution: {integrity: sha512-2SM/GZGAEkPp3KWORxQZns4M+WSeXbC2HEvmOIJe3Cmiv6ieAJvdVhDldtHqM5J1Y7MrR1XhkBT/rMlhh9FdqQ==}
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -6305,17 +6302,29 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
-  trpc-cli@0.10.2:
-    resolution: {integrity: sha512-zBkL88AeX0vQLXwEAcX6WUoT4Sopr97nFDFeD1zmW33wHQwBKbszylplNVk6BO/cuhgm/iq8/cG27NokqKA1mw==}
+  trpc-cli@0.11.0:
+    resolution: {integrity: sha512-cFt5LVl1EzwmhZtWa6xPBWr6rgLXGgEOqmcTMIYcI6fLQE1REgu6tS55LmqUJs5kVSXrOd1z5/aufJS71xUUyA==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      '@inquirer/prompts': '*'
-      omelette: '*'
+      '@orpc/server': ^1.0.0
+      '@trpc/server': ^10.45.2 || ^11.0.1
+      '@valibot/to-json-schema': ^1.1.0
+      effect: ^3.14.2 || ^4.0.0
+      valibot: ^1.1.0
+      zod: ^3.24.0 || ^4.0.0
     peerDependenciesMeta:
-      '@inquirer/prompts':
+      '@orpc/server':
         optional: true
-      omelette:
+      '@trpc/server':
+        optional: true
+      '@valibot/to-json-schema':
+        optional: true
+      effect:
+        optional: true
+      valibot:
+        optional: true
+      zod:
         optional: true
 
   ts-dedent@2.2.0:
@@ -6394,8 +6403,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ultracite@5.3.10:
-    resolution: {integrity: sha512-3eFcYZsI21RJdBkQhS6062NaxE268tx+NxfRzNRMZoJHrAPwLrGS87t9ru4IkUEbVKEElrnUM5TOpH1Z3mZkYQ==}
+  ultracite@5.4.5:
+    resolution: {integrity: sha512-UWny94qR2w4I/hzX6zsAdK9GosnL3aNr7Yq21Ltgub/GmU9mriU8Us2M9AtiPCiGPVx1Ijn8hgn8/btDLDROTg==}
     hasBin: true
 
   undici-types@6.21.0:
@@ -6702,17 +6711,6 @@ packages:
   yoctocolors-cjs@2.1.2:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
-
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
-  zod@4.1.10:
-    resolution: {integrity: sha512-XuQhz4bDMHS66VWMD/ZQI+BT4DYbOYGjhV/sIlSA4vAzMuxjLT31Oa7m6Z7lEdCGDkt1VCt0x4Ro2PHonEdKFA==}
 
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
@@ -9510,7 +9508,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@trpc/server@11.4.4(typescript@5.9.2)':
+  '@trpc/server@11.6.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
@@ -9620,8 +9618,6 @@ snapshots:
   '@types/node@24.5.2':
     dependencies:
       undici-types: 7.12.0
-
-  '@types/omelette@0.4.5': {}
 
   '@types/parse-json@4.0.2': {}
 
@@ -12178,12 +12174,12 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nypm@0.6.1:
+  nypm@0.6.2:
     dependencies:
       citty: 0.1.6
       consola: 3.4.2
       pathe: 2.0.3
-      pkg-types: 2.2.0
+      pkg-types: 2.3.0
       tinyexec: 1.0.1
 
   object-assign@4.1.1: {}
@@ -12373,7 +12369,7 @@ snapshots:
     dependencies:
       find-up: 6.3.0
 
-  pkg-types@2.2.0:
+  pkg-types@2.3.0:
     dependencies:
       confbox: 0.2.2
       exsolve: 1.0.7
@@ -13282,16 +13278,12 @@ snapshots:
 
   trough@2.2.0: {}
 
-  trpc-cli@0.10.2(typescript@5.9.2):
+  trpc-cli@0.11.0(@trpc/server@11.6.0(typescript@5.9.2))(zod@4.1.11):
     dependencies:
-      '@trpc/server': 11.4.4(typescript@5.9.2)
-      '@types/omelette': 0.4.5
       commander: 14.0.0
-      picocolors: 1.1.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.6(zod@3.25.76)
-    transitivePeerDependencies:
-      - typescript
+    optionalDependencies:
+      '@trpc/server': 11.6.0(typescript@5.9.2)
+      zod: 4.1.11
 
   ts-dedent@2.2.0: {}
 
@@ -13356,29 +13348,31 @@ snapshots:
 
   typescript@5.9.2: {}
 
-  ultracite@5.3.10(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(typescript@5.9.2):
+  ultracite@5.4.5(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)(typescript@5.9.2):
     dependencies:
       '@clack/prompts': 0.11.0
+      '@trpc/server': 11.6.0(typescript@5.9.2)
       deepmerge: 4.3.1
       jsonc-parser: 3.3.1
-      nypm: 0.6.1
-      trpc-cli: 0.10.2(typescript@5.9.2)
+      nypm: 0.6.2
+      trpc-cli: 0.11.0(@trpc/server@11.6.0(typescript@5.9.2))(zod@4.1.11)
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1)
-      zod: 4.1.10
+      zod: 4.1.11
     transitivePeerDependencies:
       - '@edge-runtime/vm'
-      - '@inquirer/prompts'
+      - '@orpc/server'
       - '@types/debug'
       - '@types/node'
+      - '@valibot/to-json-schema'
       - '@vitest/browser'
       - '@vitest/ui'
+      - effect
       - happy-dom
       - jiti
       - jsdom
       - less
       - lightningcss
       - msw
-      - omelette
       - sass
       - sass-embedded
       - stylus
@@ -13387,6 +13381,7 @@ snapshots:
       - terser
       - tsx
       - typescript
+      - valibot
       - yaml
 
   undici-types@6.21.0: {}
@@ -13557,7 +13552,7 @@ snapshots:
 
   vite@7.0.2(@types/node@22.18.6)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1):
     dependencies:
-      esbuild: 0.25.9
+      esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -13573,7 +13568,7 @@ snapshots:
 
   vite@7.0.2(@types/node@24.5.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.43.1):
     dependencies:
-      esbuild: 0.25.9
+      esbuild: 0.25.10
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -13750,14 +13745,6 @@ snapshots:
   yocto-queue@1.2.1: {}
 
   yoctocolors-cjs@2.1.2: {}
-
-  zod-to-json-schema@3.24.6(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}
-
-  zod@4.1.10: {}
 
   zod@4.1.11: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -20,12 +20,14 @@
       "persistent": true
     },
     "lint": {
-      "dependsOn": ["^lint"]
+      "dependsOn": ["^lint"],
+      "cache": false
     },
     "//#lint:root": {},
     "//#lint:ci": {},
     "format": {
-      "dependsOn": ["^format"]
+      "dependsOn": ["^format"],
+      "cache": false
     },
     "//#format:root": {},
     "tsc-check": {


### PR DESCRIPTION
Mit diesem PR wird die dependency [ultracite](https://github.com/haydenbleasel/ultracite) von Version `5.3.10` auf Version `5.4.5` aktualisiert.
Damit einher gehen auch einige Anpassungen des Codes an neue Formatting-Regeln von Ultracite.

### Referenzen
- [Release Notes](https://github.com/haydenbleasel/ultracite/releases/tag/v5.4.5)
- [Renovate Package Diff](https://app.renovatebot.com/package-diff?name=ultracite&from=5.3.10&to=5.4.5)