### PR TITLE
fix(service-config): Simplify Package structure

### DIFF
--- a/packages/service-config/index.ts
+++ b/packages/service-config/index.ts
@@ -1,5 +1,3 @@
-import type { ServiceType } from "./types";
-
 export const suiteApps: {
   title: string;
   slug: ServiceType;
@@ -18,3 +16,5 @@ export const suiteApps: {
     slug: "trader",
   },
 ];
+
+export type ServiceType = "cockpit" | "finance" | "trader" | "docs";

--- a/packages/service-config/package.json
+++ b/packages/service-config/package.json
@@ -7,7 +7,7 @@
     "format": "ultracite fix"
   },
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./index.ts"
   },
   "devDependencies": {
     "@northware/tsconfig": "workspace:*"

--- a/packages/service-config/src/index.ts
+++ b/packages/service-config/src/index.ts
@@ -1,2 +1,0 @@
-export * from "./apps";
-export * from "./types";

--- a/packages/service-config/src/types.ts
+++ b/packages/service-config/src/types.ts
@@ -1,1 +1,0 @@
-export type ServiceType = "cockpit" | "finance" | "trader" | "docs";


### PR DESCRIPTION
Das Package `@northware/service-config` verwendet jetzt nur noch eine `index.ts`, die den `suiteApps` Array und den `ServiceType` exportiert. So wird die Verwendung eines Barrel-Files vermieden. Außerdem wird kein `src/` Ordner mehr verwendet. Der export-Pfad wurde entsprechend angepasst.

