### PR TITLE
fix(ui): recharts@2.15.4 downgrade

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,7 +36,7 @@
     "react-day-picker": "^9.11.0",
     "react-hook-form": "^7.63.0",
     "react-resizable-panels": "^3.0.6",
-    "recharts": "2.15.4",
+    "recharts": "<=2.15.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,7 +303,7 @@ importers:
         specifier: ^3.0.6
         version: 3.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       recharts:
-        specifier: 2.15.4
+        specifier: <=2.15.4
         version: 2.15.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       sonner:
         specifier: ^2.0.7


### PR DESCRIPTION
Die dependency `recharts` bleibt vorerst in Version `2.15.4` bis von shadcn eine Update der Charts Komponente verfügbar ist, das mit `recharts@3` kompatibel ist.

related: #510, closes #587
