### PR TITLE
fix(github): renovate now uses minimumReleaseAge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,7 @@
   "vulnerabilityAlerts": {
     "labels": ["security", "dependencies"]
   },
+  "minimumReleaseAge": "1440 minutes",
   "dependencyDashboardLabels": ["dependencies", "github-management"],
   "dependencyDashboardTitle": "[Renovate]: Dependency Dashboard",
   "packageRules": [


### PR DESCRIPTION
since pnpm v11 now has a default minimumReleaseAge of 1440 minutes (1 day), renovate also has to know it to avoid update PR before this age of a release.
