### PR TITLE
fix(root): Renovate: Ignore PR mods by autofix.ci

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,9 @@
     "labels": ["security", "dependencies"]
   },
   "minimumReleaseAge": "1440 minutes",
+  "gitIgnoredAuthors": [
+    "autofix-ci[bot] <114827586+autofix-ci[bot]@users.noreply.github.com>"
+  ],
   "dependencyDashboardLabels": ["dependencies", "github-management"],
   "dependencyDashboardTitle": "[Renovate]: Dependency Dashboard",
   "packageRules": [


### PR DESCRIPTION
Wenn PRs von Renovate durch den autofix.ci Workflow modifiziert werden, weil dieser code-formatting ausführt, sollte Renovate diese Modifikationen ignorieren und den PR weiterhin aktuell halten und ggf. automatisch mergen.
